### PR TITLE
Add compatibility with GLPI 9.3 and fix deprecated calls

### DIFF
--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -283,9 +283,9 @@ class PluginCreditEntity extends CommonDBTM {
       echo $out;
    }
 
-   function getSearchOptionsNew() {
+   function rawSearchOptions() {
 
-      $tab = parent::getSearchOptionsNew();
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'       => 991,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -284,37 +284,40 @@ class PluginCreditTicket extends CommonDBTM {
    }
 
    /**
-    * Display contents at the end of solution form.
+    * Display voucher consumption fields at the end of a ticket processing form.
     *
     * @param array $params Array with "item" and "options" keys
     *
     * @return void
     */
-   static public function postSolutionForm($params) {
-      global $CFG_GLPI;
+   static public function displayVoucherInTicketProcessingForm($params) {
+      $item = $params['item'];
 
-      $item      = $params['item'];
-      $options   = $params['options'];
-      $showForm  = false;
-      $callers   = debug_backtrace();
-      foreach ($callers as $call) {
-         if ($call['function'] == 'showSolutionForm') {
-            $showForm = true;
-            break;
-         }
+      if (!($item instanceof ITILSolution)
+          && !($item instanceof TicketFollowup)
+          && !($item instanceof TicketTask)) {
+         return;
       }
 
-      if ($showForm) {
-         self::showMinimalForm($item);
+      if (!$item->isNewItem()) {
+         // Do not display fields in item update form.
+         return;
       }
-   }
 
-   /**
-    * Show the minimal form for declare credit.
-    *
-    * @param $ticket Ticket
-   **/
-   static function showMinimalForm(Ticket $ticket) {
+      $ticket = null;
+      if (array_key_exists('parent', $params['options'])
+          && $params['options']['parent'] instanceof Ticket) {
+         // Ticket can be found in `parent` option for TicketFollowup and TicketTask.
+         $ticket = $params['options']['parent'];
+      } else if (array_key_exists('item', $params['options'])
+                 && $params['options']['item'] instanceof Ticket) {
+         // Ticket can be found in `'item'` option for ITILSolution.
+         $ticket = $params['options']['item'];
+      }
+
+      if (!($ticket instanceof Ticket)) {
+         throw new LogicException('Ticket instance not found.');
+      }
 
       $out = "";
 
@@ -450,41 +453,65 @@ class PluginCreditTicket extends CommonDBTM {
    /**
     * Test if consumed voucher is selected and add them.
     *
-    * @param  Ticket $ticket ticket object
+    * @param CommonDBTM $item Created item
     *
     * @return boolean
     */
-   static function beforeUpdate(Ticket $ticket) {
+   static function consumeVoucher(CommonDBTM $item) {
 
-      if (!is_array($ticket->input) || !count($ticket->input)) {
-         return false;
+      if (!is_array($item->input) || !count($item->input)) {
+         return;
+      }
+
+      $ticketId = null;
+      if (array_key_exists('tickets_id', $item->fields)) {
+         // Ticket ID can be found in `tickets_id` field for TicketFollowup and TicketTask.
+         $ticketId = $item->fields['tickets_id'];
+      } else if (array_key_exists('itemtype', $item->fields)
+                 && array_key_exists('items_id', $item->fields)
+                 && 'Ticket' == $item->fields['itemtype']) {
+         // Ticket ID can be found in `items_id` field for ITILSolution.
+         $ticketId = $item->fields['items_id'];
+      }
+
+      $ticket = new Ticket();
+      if (null === $ticketId || !$ticket->getFromDB($ticketId)) {
+         return;
       }
 
       if (!is_numeric(Session::getLoginUserID(false))
           || !Session::haveRightsOr('ticket', [Ticket::STEAL, Ticket::OWN])) {
-         return false;
+         return;
       }
 
-      if (isset($ticket->input['plugin_credit_consumed_voucher'])
-          && ($ticket->input['plugin_credit_consumed_voucher'] == 1)) {
+      if (!isset($item->input['plugin_credit_consumed_voucher'])
+          || $item->input['plugin_credit_consumed_voucher'] != 1) {
+         return;
+      }
 
-         if ($ticket->input['plugin_credit_entities_id']==0) {
-            unset($ticket->input['status']);
-            unset($ticket->input['solution']);
-            unset($ticket->input['solutiontypes_id']);
-            Session::addMessageAfterRedirect(__('You must provide an credit voucher',
-                                    'credit'), true, ERROR);
-         } else {
-            $PluginCreditTicket = new self();
-            $input = ['tickets_id'                => $ticket->getID(),
-                      'plugin_credit_entities_id' => $ticket->input['plugin_credit_entities_id'],
-                      'consumed'                  => $ticket->input['plugin_credit_quantity'],
-                      'users_id'                  => Session::getLoginUserID()];
-            if ($PluginCreditTicket->add($input)) {
-               Session::addMessageAfterRedirect(__('Credit voucher successfully added.',
-                                       'credit'), true, INFO);
-            }
-         }
+      if (!isset($item->input['plugin_credit_entities_id'])
+          || $item->input['plugin_credit_entities_id'] == 0) {
+         Session::addMessageAfterRedirect(
+            __('You must provide an credit voucher', 'credit'),
+            true,
+            ERROR
+         );
+         return;
+      }
+
+      $PluginCreditTicket = new self();
+      $input = [
+         'tickets_id'                => $ticket->getID(),
+         'plugin_credit_entities_id' => $item->input['plugin_credit_entities_id'],
+         'consumed'                  => $item->input['plugin_credit_quantity'],
+         'users_id'                  => Session::getLoginUserID(),
+      ];
+      if ($PluginCreditTicket->add($input)) {
+         Session::addMessageAfterRedirect(
+            __('Credit voucher successfully added.', 'credit'),
+            true,
+            INFO
+         );
       }
    }
 
@@ -572,5 +599,4 @@ class PluginCreditTicket extends CommonDBTM {
       $migration->displayMessage("Uninstalling $table");
       $migration->dropTable($table);
    }
-
 }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -489,8 +489,8 @@ class PluginCreditTicket extends CommonDBTM {
    }
 
 
-   function getSearchOptionsNew() {
-      $tab = parent::getSearchOptionsNew();
+   function rawSearchOptions() {
+      $tab = parent::rawSearchOptions();
 
       $tab[] = [
          'id'       => 881,

--- a/setup.php
+++ b/setup.php
@@ -26,9 +26,9 @@
 define('PLUGIN_CREDIT_VERSION', '1.1.1');
 
 // Minimal GLPI version, inclusive
-define("PLUGIN_CREDIT_MIN_GLPI", "9.2");
+define("PLUGIN_CREDIT_MIN_GLPI", "9.3");
 // Maximum GLPI version, exclusive
-define("PLUGIN_CREDIT_MAX_GLPI", "9.3");
+define("PLUGIN_CREDIT_MAX_GLPI", "9.4");
 
 /**
  * Init hooks of the plugin.

--- a/setup.php
+++ b/setup.php
@@ -57,11 +57,16 @@ function plugin_init_credit() {
       if (Session::haveRightsOr('ticket', [Ticket::STEAL, Ticket::OWN])) {
          Plugin::registerClass('PluginCreditTicket', ['addtabon' => 'Ticket']);
 
-         $PLUGIN_HOOKS['post_item_form']['credit'] =
-            ['PluginCreditTicket', 'postSolutionForm'];
+         $PLUGIN_HOOKS['post_item_form']['credit'] = [
+            'PluginCreditTicket',
+            'displayVoucherInTicketProcessingForm'
+         ];
 
-         $PLUGIN_HOOKS['pre_item_update']['credit'] =
-            ['Ticket' => ['PluginCreditTicket', 'beforeUpdate']];
+         $PLUGIN_HOOKS['pre_item_add']['credit'] = [
+            'ITILSolution'   => ['PluginCreditTicket', 'consumeVoucher'],
+            'TicketFollowup' => ['PluginCreditTicket', 'consumeVoucher'],
+            'TicketTask'     => ['PluginCreditTicket', 'consumeVoucher'],
+         ];
       }
    }
 }


### PR DESCRIPTION
In GLPI 9.2, it was possible to add a voucher consumption without submitting a solution (by submitting an empty solution). As it is not possible anymore in GLPI 9.3, I added voucher consumption fielsds in TicketFollowup form (and in TicketTask as it is working similarly).