### PR TITLE
Prevent consuming more credits than available

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -500,6 +500,23 @@ class PluginCreditTicket extends CommonDBTM {
       }
 
       $PluginCreditTicket = new self();
+
+      $PluginCreditEntity = new PluginCreditEntity();
+      $PluginCreditEntity->getFromDB($item->input['plugin_credit_entities_id']);
+
+      $quantity=$PluginCreditEntity->getField('quantity');
+      $quantity_consumed=$PluginCreditTicket->getConsumedForCreditEntity($item->input['plugin_credit_entities_id']);
+      $quantity_remain=$quantity-$quantity_consumed;
+
+      if ($quantity_remain<$item->input['plugin_credit_quantity']) {
+         Session::addMessageAfterRedirect(
+            __('Quantity consumed exceeds remaining credits: ', 'credit').$quantity_remain,
+            true,
+            ERROR
+         );
+         return false;
+      }
+
       $input = [
          'tickets_id'                => $ticket->getID(),
          'plugin_credit_entities_id' => $item->input['plugin_credit_entities_id'],


### PR DESCRIPTION
If the user tries to consume more credits than available, he will not save the consumption and will show an error message informing of how many credits are available