### PR TITLE
Feature/overconsumption

### DIFF
--- a/ajax/dropdownQuantity.php
+++ b/ajax/dropdownQuantity.php
@@ -1,0 +1,49 @@
+<?php
+
+include ("../../../inc/includes.php");
+header("Content-Type: text/html; charset=UTF-8");
+Html::header_nocache();
+
+Session::checkLoginUser();
+
+if (isset($_POST["entity"])) {
+
+   $entity_query = [
+      'SELECT' => ['overconsumption_allowed', 'quantity'],
+      'FROM'   => 'glpi_plugin_credit_entities',
+      'WHERE'  => [
+         'id' => $_POST['entity'],
+      ],
+   ];
+   $entity_result = $DB->request($entity_query)->next();
+
+   $overconsumption_allowed = $entity_result['overconsumption_allowed'];
+   $quantity_sold           = (int)$entity_result['quantity'];
+
+   if (0 !== $quantity_sold && !$overconsumption_allowed) {
+      $ticket_query = [
+         'SELECT' => [
+            'SUM' => 'consumed AS consumed_total',
+         ],
+         'FROM'   => 'glpi_plugin_credit_tickets',
+         'WHERE'  => [
+            'plugin_credit_entities_id' => $_POST['entity'],
+         ],
+      ];
+      $ticket_result = $DB->request($ticket_query)->next();
+
+      $consumed = (int)$ticket_result['consumed_total'];
+      $max      = max(0, $quantity_sold - $consumed);
+
+      Dropdown::showNumber("plugin_credit_quantity", ['value'   => '',
+                                                      'min'     => 0,
+                                                      'max'     => $max,
+                                                      'step'    => 1,]);
+   } else {
+      Dropdown::showNumber("plugin_credit_quantity", ['value'   => '',
+                                                      'min'     => 0,
+                                                      'max'     => 200,
+                                                      'step'    => 1,]);
+   }
+
+}


### PR DESCRIPTION
Following the recommendation of @flegastelois in #43 I added the overconsumption field for each credit voucher.
![image](https://user-images.githubusercontent.com/39123808/46731729-c3112000-cc8b-11e8-9014-aa66ef569b82.png)
In ticket when select a credit voucher with overconsumption disabled the dropdown is limited #44 
![image](https://user-images.githubusercontent.com/39123808/46731775-e20fb200-cc8b-11e8-97ac-000f3535d27b.png)
![image](https://user-images.githubusercontent.com/39123808/46731810-f6ec4580-cc8b-11e8-80b1-edecdaadbd79.png)
And when a credit voucher with overconsumption activated consumed more credits than available show warning  #43 
![image](https://user-images.githubusercontent.com/39123808/46731964-68c48f00-cc8c-11e8-81eb-2c263c91ec43.png)


