### PR TITLE
Fix fatal error on other CommonITILObject types

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -307,24 +307,18 @@ class PluginCreditTicket extends CommonDBTM {
          return;
       }
 
-      // Item might be another CommonITILObject, we only want Ticket
-      if (!$params['options']['item'] instanceof Ticket) {
-         return;
-      }
-
       $ticket = null;
-      if (array_key_exists('parent', $params['options'])
-          && $params['options']['parent'] instanceof Ticket) {
+      if (array_key_exists('parent', $params['options'])) {
          // Ticket can be found in `parent` option for TicketTask.
          $ticket = $params['options']['parent'];
-      } else if (array_key_exists('item', $params['options'])
-                 && $params['options']['item'] instanceof Ticket) {
+      } else if (array_key_exists('item', $params['options'])) {
          // Ticket can be found in `'item'` option for ITILFollowup and ITILSolution.
          $ticket = $params['options']['item'];
       }
 
+      // Item might be another CommonITILObject, we only want Ticket
       if (!($ticket instanceof Ticket)) {
-         throw new LogicException('Ticket instance not found.');
+         return;
       }
 
       $out = "";

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -307,6 +307,11 @@ class PluginCreditTicket extends CommonDBTM {
          return;
       }
 
+      // Item might be another CommonITILObject, we only want Ticket
+      if (!$params['options']['item'] instanceof Ticket) {
+         return;
+      }
+
       $ticket = null;
       if (array_key_exists('parent', $params['options'])
           && $params['options']['parent'] instanceof Ticket) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -308,16 +308,19 @@ class PluginCreditTicket extends CommonDBTM {
       }
 
       $ticket = null;
-      if (array_key_exists('parent', $params['options'])) {
+      if (array_key_exists('parent', $params['options'])
+          && $params['options']['parent'] instanceof Ticket) {
          // Ticket can be found in `parent` option for TicketTask.
          $ticket = $params['options']['parent'];
-      } else if (array_key_exists('item', $params['options'])) {
+      } else if (array_key_exists('item', $params['options'])
+         && $params['options']['item'] instanceof Ticket) {
          // Ticket can be found in `'item'` option for ITILFollowup and ITILSolution.
          $ticket = $params['options']['item'];
       }
 
-      // Item might be another CommonITILObject, we only want Ticket
-      if (!($ticket instanceof Ticket)) {
+      // No parent of type Ticket found, parent might we might be an another
+      // type of CommonITILObject so we should exit here
+      if ($ticket === null) {
          return;
       }
 


### PR DESCRIPTION
Internal ref: 18332.  
  
  
Example: if we try to add a solution to a problem we will trigger this exception:
```php
if (!($ticket instanceof Ticket)) {
    throw new LogicException('Ticket instance not found.');
}
```

This exception is supposed to be triggered only if the matching ticket is not found for some very unlikely reasons (so this assume the parent IS a ticket).

This code should not be reached if the parent item is not a Ticket, hence this proposal.

