### PR TITLE
feat: consume credit

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Credit plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Credit.
+ *
+ * Credit is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Credit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Credit. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @author    François Legastelois
+ * @copyright Copyright (C) 2017-2022 by Credit plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/credit
+ * -------------------------------------------------------------------------
+ */
+
+/** @file
+* @brief
+*/
+
+use Glpi\Event;
+
+include ('../../../inc/includes.php');
+
+Session::haveRight("ticket", UPDATE);
+
+$PluginCreditTicket = new PluginCreditTicket();
+
+$input = [
+    'tickets_id'                => $_REQUEST['tickets_id'],
+    'plugin_credit_entities_id' => $_REQUEST['plugin_credit_entities_id'],
+    'consumed'                  => $_REQUEST['plugin_credit_quantity'],
+    'users_id'                  => Session::getLoginUserID(),
+];
+if ($PluginCreditTicket->add($input)) {
+    Session::addMessageAfterRedirect(
+        __('Credit voucher successfully added.', 'credit'),
+        true,
+        INFO
+    );
+    Html::back();
+}
+
+Html::displayErrorAndDie("lost");

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -172,6 +172,48 @@ class PluginCreditTicket extends CommonDBTM {
       }
 
       $out = "";
+      if ($canedit) {
+         $rand = mt_rand();
+         $out .= "<div class='firstbloc'>";
+         $out .= "<form name='creditentity_form$rand' id='creditentity_form$rand' method='post' action='";
+         $out .= self::getFormUrl()."'>";
+         $out .= "<input type='hidden' name='tickets_id' value='$ID'>";
+         $out .= "<label for='voucher'>";
+         $out .= __('Voucher name', 'credit');
+         $out .= "</label>";
+         $out .= ' ';
+         $out .= PluginCreditEntity::dropdown(
+            [
+               'name'      => 'plugin_credit_entities_id',
+               'comments'  => false,
+               'entity'    => $ticket->getEntityID(),
+               'entity_sons' => true,
+               'display'   => false,
+               'condition' => ['is_active' => 1],
+               'rand'      => $rand
+            ]
+         );
+         $out .= ' ';
+         $out .= "<label for='plugin_credit_quantity'>";
+         $out .= __('Quantity consumed', 'credit');
+         $out .= "</label>";
+         $out .= ' ';
+         $out .= "<span id='plugin_credit_quantity_container$rand'>";
+         $out .= Dropdown::showNumber('', ['value' => null, 'min' => 0, 'max' => 0, 'display' => false]); // placeholder
+         $out .= "</span>";
+         $out .= Ajax::updateItemOnSelectEvent(
+            "dropdown_plugin_credit_entities_id$rand",
+            "plugin_credit_quantity_container$rand",
+            Plugin::getWebDir('credit') . "/ajax/dropdownQuantity.php",
+            ['entity' => '__VALUE__'],
+            false
+         );
+         $out .= ' ';
+         $out .= "<input type='submit' name='add' value='"._sx('button', 'Add')."' class='submit'>";
+         $out .= Html::closeForm(false);
+         $out .= "</div>";
+      }
+
       $out .= "<div class='spaced'>";
       $out .= "<table class='tab_cadre_fixe'>";
       $out .= "<tr class='tab_bg_1'><th colspan='2'>";


### PR DESCRIPTION
Allow adding a credit consumption only from the credit tab of the ticket (without it being linked to a follow-up or a task)
~Allow to modify the credit consumption of a closed ticket for admins.~

*Request from Pierre*