### PR TITLE
fix(followup): credit consumed even if the followup fails

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -67,14 +67,11 @@ function plugin_init_credit() {
             'displayVoucherInTicketProcessingForm'
          ];
 
-         $PLUGIN_HOOKS['pre_item_add']['credit'] = [
+         $PLUGIN_HOOKS['item_add']['credit'] = [
             'ITILFollowup'   => ['PluginCreditTicket', 'consumeVoucher'],
             'ITILSolution'   => ['PluginCreditTicket', 'consumeVoucher'],
             'TicketTask'     => ['PluginCreditTicket', 'consumeVoucher'],
-         ];
-
-         $PLUGIN_HOOKS['item_add']['credit'] = [
-            'Ticket' => ['PluginCreditTicketConfig', 'updateConfig'],
+            'Ticket'         => ['PluginCreditTicketConfig', 'updateConfig'],
          ];
          // Update config on 'pre_item_update' as only changing these fields in ticket form will not trigger 'item_update'.
          $PLUGIN_HOOKS['pre_item_update']['credit'] = [


### PR DESCRIPTION
When credits are consumed on the add follow-up form and the form was invalid (e.g. empty content) the follow-up is not created (normal) but the credit was still consumed.

Same with the tasks and solution.

!23861