### PR TITLE
Move credits to another entity

### DIFF
--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -208,15 +208,24 @@ class PluginCreditEntity extends CommonDBTM {
          if ($canedit) {
             $rand = mt_rand();
             $out .= Html::getOpenMassiveActionsForm('mass'.__CLASS__.$rand);
+
+            $specific_actions = [
+               'update' => _x('button', 'Update'),
+               'purge'  => _x('button', 'Delete permanently'),
+            ];
+            MassiveAction::getAddTransferList($specific_actions);
+
+            // Remove icons
+            $specific_actions = array_map(function ($action) {
+               return strip_tags($action);
+            }, $specific_actions);
+
             $massiveactionparams = [
                'num_displayed'    => $number,
                'container'        => 'mass'.__CLASS__.$rand,
                'rand'             => $rand,
                'display'          => false,
-               'specific_actions' => [
-                  'update' => _x('button', 'Update'),
-                  'purge'  => _x('button', 'Delete permanently')
-               ]
+               'specific_actions' => $specific_actions,
             ];
             $out .= Html::showMassiveActions($massiveactionparams);
          }


### PR DESCRIPTION
Credits are currently set on one entity and can't be moved to another.

These changes add the "Add to transfer list" massive action to allow credits' target entity to be changed.

![image](https://user-images.githubusercontent.com/42734840/227883860-005dbad6-22b8-4146-ab68-57a24e9e38a7.png)
