### PR TITLE
fix: prevent sql error

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -125,7 +125,7 @@ function plugin_credit_get_datas(NotificationTargetTicket $target)
         'SELECT' => [
             'name',
             'quantity',
-            'consumed_on_ticket' => new QuerySubQuery([
+            new QuerySubQuery([
                 'SELECT' => [
                     'SUM' => 'consumed AS consumed_on_ticket',
                 ],
@@ -136,8 +136,8 @@ function plugin_credit_get_datas(NotificationTargetTicket $target)
                     'plugin_credit_entities_id' => new QueryExpression($DB->quoteName('glpi_plugin_credit_entities.id')),
                     'tickets_id' => $id,
                 ],
-            ]),
-            'consumed_total' => new QuerySubQuery([
+            ], 'consumed_on_ticket'),
+            new QuerySubQuery([
                 'SELECT' => [
                     'SUM' => 'consumed AS consumed_total',
                 ],
@@ -147,7 +147,7 @@ function plugin_credit_get_datas(NotificationTargetTicket $target)
                 'WHERE' => [
                     'plugin_credit_entities_id' => new QueryExpression($DB->quoteName('glpi_plugin_credit_entities.id')),
                 ],
-            ]),
+            ], 'consumed_total'),
         ],
         'FROM' => [
             'glpi_plugin_credit_entities',


### PR DESCRIPTION
!31274

Prevent error in sql-error.log

 ```
glpisqllog.ERROR: DBmysql::doQuery() in .../src/DBmysql.php line 403
  *** MySQL query error:
  SQL: SELECT `name`, `quantity`, `consumed_on_ticket`.`(SELECT SUM(`consumed`)` AS `consumed_on_ticket` FROM `glpi_plugin_credit_tickets` WHERE `plugin_credit_entities_id` = `glpi_plugin_credit_entities`.`id` AND `tickets_id` = '0000284'), `consumed_total`.`(SELECT SUM(`consumed`)` AS `consumed_total` FROM `glpi_plugin_credit_tickets` WHERE `plugin_credit_entities_id` = `glpi_plugin_credit_entities`.`id`) FROM `glpi_plugin_credit_entities` WHERE `is_active` = '1' AND `entities_id` = '0'
  Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '`)` AS `consumed_on_ticket` FROM `glpi_plugin_credit_tickets` WHERE `plugin_cred' at line 1
  Backtrace :
  src/DBmysqlIterator.php:112                        DBmysql->doQuery()
  src/DBmysql.php:1109                               DBmysqlIterator->execute()
  plugins/credit/hook.php:161                        DBmysql->request()
  src/Plugin.php:1680                                plugin_credit_get_datas()
  src/NotificationTarget.php:1399                    Plugin::doHook()
  src/NotificationTemplate.php:279                   NotificationTarget->getForTemplate()
  src/NotificationEventAbstract.php:125              NotificationTemplate->getTemplateByLanguage()
  src/NotificationEvent.php:187                      NotificationEventAbstract::raise()
  src/ITILFollowup.php:285                           NotificationEvent::raiseEvent()
  src/CommonDBTM.php:1343                            ITILFollowup->post_addItem()
  front/itilfollowup.form.php:58                     CommonDBTM->add()
  public/index.php:82                                require()
```