### PR TITLE
Add credit consumed notification

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -74,8 +74,8 @@ function plugin_credit_install()
         'lowcredits',
         DAY_TIMESTAMP,
         [
-             'comment' => '',
-             'mode' => CronTask::MODE_INTERNAL,
+            'comment' => '',
+            'mode' => CronTask::MODE_INTERNAL,
         ]
     );
 

--- a/hook.php
+++ b/hook.php
@@ -71,7 +71,7 @@ function plugin_credit_install()
 
     CronTask::register(
         'PluginCreditEntity',
-        'fewquantityremaining',
+        'lowcredits',
         DAY_TIMESTAMP,
         [
            'comment' => '',

--- a/hook.php
+++ b/hook.php
@@ -74,10 +74,10 @@ function plugin_credit_install()
         'lowcredits',
         DAY_TIMESTAMP,
         [
-           'comment' => '',
-           'mode' => CronTask::MODE_INTERNAL,
+             'comment' => '',
+             'mode' => CronTask::MODE_INTERNAL,
         ]
-     );
+    );
 
     return true;
 }

--- a/hook.php
+++ b/hook.php
@@ -69,6 +69,16 @@ function plugin_credit_install()
         ]
     );
 
+    CronTask::register(
+        'PluginCreditEntity',
+        'fewquantityremaining',
+        DAY_TIMESTAMP,
+        [
+           'comment' => '',
+           'mode' => CronTask::MODE_INTERNAL,
+        ]
+     );
+
     return true;
 }
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -656,6 +656,9 @@ SQL;
 
             // 1.10.0
             $migration->dropField($table, 'is_default'); // Was created during dev phase of 1.10.0, then removed
+
+            // 1.13.2
+            $migration->addField($table, 'low_credit_alert', 'int', ['update' => "NULL"]);
         }
 
         return true;

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -587,7 +587,7 @@ class PluginCreditEntity extends CommonDBTM
             $task->addVolume(1);
             $task->log(
                 sprintf(
-                    'Credit %s has been consumed',
+                    'Low credit for %s',
                     $credit_data['name'],
                 )
             );

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -549,6 +549,10 @@ class PluginCreditEntity extends CommonDBTM
 
     public static function cronLowCredits($task)
     {
+        /**
+         * @var array $CFG_GLPI
+         * @var DBmysql $DB
+         */
         global $CFG_GLPI, $DB;
 
         if (!$CFG_GLPI['use_notifications']) {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -559,8 +559,8 @@ class PluginCreditEntity extends CommonDBTM
         $credits_iterator = $DB->request(
             [
                 'SELECT' => [
-                    'glpi_plugin_credit_entities.*',
-                    new QueryExpression('SUM(glpi_plugin_credit_tickets.consumed) AS quantity_consumed')
+                    'glpi_plugin_credit_entities.id',
+                    'glpi_plugin_credit_entities.name',
                 ],
                 'FROM' => 'glpi_plugin_credit_entities',
                 'LEFT JOIN' => [

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -591,7 +591,7 @@ class PluginCreditEntity extends CommonDBTM
          $credit = new PluginCreditEntity();
          $credit->getFromDB($credit_data['id']);
 
-         NotificationEvent::raiseEvent('consumed', $credit);
+         NotificationEvent::raiseEvent('fewquantityremaining', $credit);
 
          $input = [
             'type' => Alert::END,

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -210,8 +210,8 @@ class PluginCreditEntity extends CommonDBTM
             $out .= "</tr>";
             $out .= "<tr class='tab_bg_1'>";
             $out .= "<td colspan='3'>";
-            $out .= __('Alert threshold on quantity remaining') . "</td><td>";
-            $out .= Dropdown::showNumber("quantity_alert_rate", ['value'   => -1,
+            $out .= __('Low credit alert threshold') . "</td><td>";
+            $out .= Dropdown::showNumber("low_credit_alert", ['value'   => -1,
                 'min'     => 0,
                 'max'     => 50,
                 'step'    => 10,
@@ -280,7 +280,7 @@ class PluginCreditEntity extends CommonDBTM
             $header_end .= "<th>" . __('Quantity consumed', 'credit') . "</th>";
             $header_end .= "<th>" . __('Quantity remaining', 'credit') . "</th>";
             $header_end .= "<th>" . __('Allow overconsumption', 'credit') . "</th>";
-            $header_end .= "<th>" .__('Quantity alert rate') . "</th>";
+            $header_end .= "<th>" .__('Low credits alert') . "</th>";
             $header_end .= "<th>" . __('Entity') . "</th>";
             $header_end .= "<th>" . __('Child entities') . "</th>";
             $header_end .= "</tr>";
@@ -355,7 +355,7 @@ class PluginCreditEntity extends CommonDBTM
                 $out .= "</td>";
 
                 $out .= "<td>";
-                $out .= $data["quantity_alert_rate"] == -1 ? __('Disabled') : $data["quantity_alert_rate"] . '%';
+                $out .= $data["low_credit_alert"] == -1 ? __('Disabled') : $data["low_credit_alert"] . '%';
                 $out .= "</td>";
 
                 $out .= "<td>";
@@ -441,8 +441,8 @@ class PluginCreditEntity extends CommonDBTM
         $tab[] = [
             'id'      => 997,
             'table'   => self::getTable(),
-            'field'   => 'quantity_alert_rate',
-            'name'    => __('Quantity alert rate', 'credit'),
+            'field'   => 'low_credit_alert',
+            'name'    => __('Low credit alert', 'credit'),
             'datatype' => 'number',
             'min'     => 0,
             'max'     => 50,
@@ -462,9 +462,9 @@ class PluginCreditEntity extends CommonDBTM
                     'description' => __('Expiration date', 'credit'),
                     'parameter'   => __('Notice (in days)', 'credit')
                 ];
-            case 'fewquantityremaining':
+            case 'lowcredits':
                 return [
-                    'description' => __('Few quantity remaining', 'credit'),
+                    'description' => __('Low credits', 'credit'),
                 ];
         }
         return [];
@@ -547,7 +547,7 @@ class PluginCreditEntity extends CommonDBTM
         return 1;
     }
 
-    static function cronFewQuantityRemaining($task)
+    static function cronLowCredits($task)
    {
       global $CFG_GLPI, $DB;
 
@@ -575,7 +575,7 @@ class PluginCreditEntity extends CommonDBTM
               'glpi_plugin_credit_entities.is_active' => 1,
            ],
            'GROUPBY' => 'glpi_plugin_credit_entities.id',
-           'HAVING' => new QueryExpression('glpi_plugin_credit_entities.quantity - quantity_consumed <= (glpi_plugin_credit_entities.quantity * glpi_plugin_credit_entities.quantity_alert_rate) / 100')
+           'HAVING' => new QueryExpression('glpi_plugin_credit_entities.quantity - quantity_consumed <= (glpi_plugin_credit_entities.quantity * glpi_plugin_credit_entities.low_credit_alert) / 100')
         ]
      );
 
@@ -591,7 +591,7 @@ class PluginCreditEntity extends CommonDBTM
          $credit = new PluginCreditEntity();
          $credit->getFromDB($credit_data['id']);
 
-         NotificationEvent::raiseEvent('fewquantityremaining', $credit);
+         NotificationEvent::raiseEvent('lowcredits', $credit);
 
          $input = [
             'type' => Alert::END,
@@ -634,7 +634,7 @@ class PluginCreditEntity extends CommonDBTM
                     `end_date` timestamp NULL DEFAULT NULL,
                     `quantity` int NOT NULL DEFAULT '0',
                     `overconsumption_allowed` tinyint NOT NULL DEFAULT '0',
-                    `quantity_alert_rate` int DEFAULT NULL,
+                    `low_credit_alert` int DEFAULT NULL,
                     PRIMARY KEY (`id`),
                     KEY `name` (`name`),
                     KEY `entities_id` (`entities_id`),

--- a/inc/notificationtargetentity.class.php
+++ b/inc/notificationtargetentity.class.php
@@ -386,6 +386,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
             ]
         );
         foreach ($templates_iterator_quantity as $template_data_quantity) {
+            $translation = new NotificationTemplateTranslation();
             $translations_iterator_quantity = $DB->request(
                 [
                     'SELECT' => 'id',
@@ -396,6 +397,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
                 ]
             );
             foreach ($translations_iterator_quantity as $translation_data_quantity) {
+                $translation = new NotificationTemplateTranslation();
                 $translation->delete($translation_data_quantity);
             }
 

--- a/inc/notificationtargetentity.class.php
+++ b/inc/notificationtargetentity.class.php
@@ -309,7 +309,6 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
                         'items_id' => Notification::ENTITY_ADMINISTRATOR,
                     ]
                 );
-
             }
         }
     }

--- a/inc/notificationtargetentity.class.php
+++ b/inc/notificationtargetentity.class.php
@@ -35,7 +35,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
     {
         return [
             'expired' => __('Expiration date', 'credit'),
-            'fewquantityremaining' => __('Few quantity remaining', 'credit')
+            'lowcredits' => __('Low credits', 'credit')
         ];
     }
 
@@ -118,8 +118,8 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
         $lang = [
             'credit.expired'             => __('Credit voucher expiration', 'credit'),
             'credit.expired.information' => __('This credit voucher will expire soon. Please, consider buying a new one.', 'credit'),
-            'credit.fewquantityremaining' => __('Amount of credit remaining close to or at 0', 'credit'),
-            'credit.fewquantityremaining.information' => __('The remaining quantity has reached 0 or almost.', 'credit'),
+            'credit.lowcredits' => __('Amount of credit remaining close to or at 0', 'credit'),
+            'credit.lowcredits.information' => __('The remaining quantity has reached 0 or almost.', 'credit'),
         ];
 
         foreach ($lang as $tag => $label) {
@@ -238,7 +238,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
                 'FROM' => 'glpi_notificationtemplates',
                 'WHERE' => [
                     'itemtype' => 'PluginCreditEntity',
-                    'name' => 'Few quantity remaining',
+                    'name' => 'Low credits',
                 ]
             ]
         );
@@ -249,7 +249,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
         } else {
             $templates_id_quantity = $template->add(
                 [
-                    'name' => 'Few quantity remaining',
+                    'name' => 'Low credits',
                     'itemtype' => 'PluginCreditEntity',
                     'date_mod' => $_SESSION['glpi_currenttime'],
                     'comment' => '',
@@ -268,25 +268,25 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
                     [
                         'notificationtemplates_id' => $templates_id_quantity,
                         'language' => '',
-                        'subject' => '##lang.credit.fewquantityremaining## : ##credit.name##',
-                        'content_text' => '##lang.credit.fewquantityremaining.information##',
-                        'content_html' => '##lang.credit.fewquantityremaining.information##',
+                        'subject' => '##lang.credit.lowcredits## : ##credit.name##',
+                        'content_text' => '##lang.credit.lowcredits.information##',
+                        'content_html' => '##lang.credit.lowcredits.information##',
                     ]
                 );
             }
 
             $notifications_count_quantity = countElementsInTable(
                 $notification->getTable(),
-                ['itemtype' => 'PluginCreditEntity', 'event' => 'fewquantityremaining']
+                ['itemtype' => 'PluginCreditEntity', 'event' => 'lowcredits']
             );
 
             if ($notifications_count_quantity == 0) {
                 $notification_id_quantity = $notification->add(
                     [
-                        'name' => 'Few quantity remaining',
+                        'name' => 'Low credits',
                         'entities_id' => 0,
                         'itemtype' => 'PluginCreditEntity',
-                        'event' => 'fewquantityremaining',
+                        'event' => 'lowcredits',
                         'comment' => '',
                         'is_recursive' => 1,
                         'is_active' => 1,
@@ -368,7 +368,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
                 'FROM' => $notification->getTable(),
                 'WHERE' => [
                     'itemtype' => 'PluginCreditEntity',
-                    'event' => 'fewquantityremaining',
+                    'event' => 'lowcredits',
                 ],
             ]
         );
@@ -382,7 +382,7 @@ class PluginCreditNotificationTargetEntity extends NotificationTarget
                 'FROM' => $template->getTable(),
                 'WHERE' => [
                     'itemtype' => 'PluginCreditEntity',
-                    'name' => 'Few quantity remaining',
+                    'name' => 'lowcredits',
                 ],
             ]
         );


### PR DESCRIPTION
Hello,

We would like an alert to be triggered when the remaining quantity on a credit is close to or equal to 0.
![image](https://github.com/pluginsGLPI/credit/assets/99427405/dae6e313-c0aa-4a2f-a4d5-82b00c345c30)

We would like a threshold (in percentage of quantity initially allocated to the credit) to be definable. when the remaining quantity reaches or falls below this threshold, the alert is triggered
![image](https://github.com/pluginsGLPI/credit/assets/99427405/6c90fca9-10db-4660-9be8-61722a7bd096)

I of course had to add a field to the glpi_plugin_credit_entities table to store this value
![image](https://github.com/pluginsGLPI/credit/assets/99427405/c192c0f3-55a3-4252-be82-1c5d93669ba5)

i haven't updated the locales.

Please let us know if it is okay for you to add such a feature

BESSIERES Anthony from IT Gouvernance