### PR TITLE
New "visible on incident" & "visible on request" features

### DIFF
--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -305,7 +305,7 @@ class PluginCreditEntity extends CommonDBTM
                 $sqlfilter = [
                     'is_active' => '1'
                 ];
-                
+
                 if ($ticket_type !== null) {
                     if ($ticket_type == 1) { // Incident
                         $sqlfilter['visible_on_incident'] = 1;
@@ -714,7 +714,7 @@ SQL;
 
             // 1.13.2
             $migration->addField($table, 'low_credit_alert', 'int', ['update' => "NULL"]);
-            
+
             // new
             $migration->addField($table, 'visible_on_incident', 'bool', ['update' => "1"]);
             $migration->addField($table, 'visible_on_request', 'bool', ['update' => "1"]);
@@ -763,13 +763,13 @@ SQL;
     public static function getActiveFilterForTicketType($ticket_type)
     {
         $filter = self::getActiveFilter();
-        
+
         if ($ticket_type == 1) { // Incident
             $filter['glpi_plugin_credit_entities.visible_on_incident'] = 1;
         } elseif ($ticket_type == 2) { // Request
             $filter['glpi_plugin_credit_entities.visible_on_request'] = 1;
         }
-        
+
         return $filter;
     }
 }

--- a/inc/entityconfig.class.php
+++ b/inc/entityconfig.class.php
@@ -136,10 +136,11 @@ class PluginCreditEntityConfig extends CommonDBTM
      *
      * @param int     $entity_id
      * @param string  $itemtype
+     * @param int     $ticket_type Ticket type (1=Incident, 2=Request)
      *
      * @return null|int
      */
-    public static function getDefaultForEntityAndType($entity_id, $itemtype)
+    public static function getDefaultForEntityAndType($entity_id, $itemtype, $ticket_type = null)
     {
         $config = new self();
         $config->getFromDBByCrit(['entities_id' => $entity_id]);
@@ -159,10 +160,18 @@ class PluginCreditEntityConfig extends CommonDBTM
                 break;
         }
 
-        $criteria = array_merge(
-            ['id' => $voucher_id],
-            PluginCreditEntity::getActiveFilter()
-        );
+        if ($voucher_id && $ticket_type) {
+            $criteria = array_merge(
+                ['id' => $voucher_id],
+                PluginCreditEntity::getActiveFilterForTicketType($ticket_type)
+            );
+        } else {
+            $criteria = array_merge(
+                ['id' => $voucher_id],
+                PluginCreditEntity::getActiveFilter()
+            );
+        }
+
         if (countElementsInTable(PluginCreditEntity::getTable(), $criteria) === 0) {
             $voucher_id = null;
         }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -428,7 +428,7 @@ class PluginCreditTicket extends CommonDBTM
             $default_credit = PluginCreditTicketConfig::getDefaultForTicket($ticket->getID(), $item->getType());
             if ($default_credit == 0) {
                 //get default value for entity
-                $default_credit = PluginCreditEntityConfig::getDefaultForEntityAndType($ticket->getEntityID(), $item->getType());
+                $default_credit = PluginCreditEntityConfig::getDefaultForEntityAndType($ticket->getEntityID(), $item->getType(), $ticket->fields['type']);
             }
 
             $out .= PluginCreditEntity::dropdown(['name'      => 'plugin_credit_entities_id',

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -199,7 +199,7 @@ class PluginCreditTicket extends CommonDBTM
                     'comments'  => false,
                     'entity'    => $ticket->getEntityID(),
                     'display'   => false,
-                    'condition' => PluginCreditEntity::getActiveFilter(),
+                    'condition' => PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type']),
                     'rand'      => $rand
                 ]
             );
@@ -332,7 +332,7 @@ class PluginCreditTicket extends CommonDBTM
 
         $Entity = new Entity();
         $Entity->getFromDB($ticket->fields['entities_id']);
-        PluginCreditEntity::showForItemtype($Entity, 'Ticket');
+        PluginCreditEntity::showForItemtype($Entity, 'Ticket', $ticket->fields['type']);
     }
 
     /**
@@ -435,7 +435,7 @@ class PluginCreditTicket extends CommonDBTM
                 'entity'    => $ticket->getEntityID(),
                 'display'   => false,
                 'value'     => $default_credit,
-                'condition' => PluginCreditEntity::getActiveFilter(),
+                'condition' => PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type']),
                 'rand'      => $rand
             ]);
             $out .= "</td><td colspan='2'></td>";

--- a/inc/ticketconfig.class.php
+++ b/inc/ticketconfig.class.php
@@ -51,6 +51,11 @@ class PluginCreditTicketConfig extends CommonDBTM
      */
     public static function getDefaultForTicket($ticket_id, $itemtype)
     {
+        $ticket = new Ticket();
+        if (!$ticket->getFromDB($ticket_id)) {
+            return null;
+        }
+
         $ticket_config = new self();
         $ticket_config->getFromDBByCrit(['tickets_id' => $ticket_id]);
 
@@ -71,7 +76,7 @@ class PluginCreditTicketConfig extends CommonDBTM
 
         $criteria = array_merge(
             ['id' => $voucher_id],
-            PluginCreditEntity::getActiveFilter()
+            PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type'])
         );
         if (countElementsInTable(PluginCreditEntity::getTable(), $criteria) === 0) {
             $voucher_id = null;
@@ -113,7 +118,7 @@ class PluginCreditTicketConfig extends CommonDBTM
                 'entity_sons' => true,
                 'display'     => false,
                 'value'       => $ticket->input['plugin_credit_entities_id_default'] ?? 0,
-                'condition'   => PluginCreditEntity::getActiveFilter(),
+                'condition'   => PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type']),
                 'comments'    => false,
                 'rand'        => $rand,
                 'on_change'   => 'PluginCredit.propagateDefaultVoucherValue(this)',
@@ -128,7 +133,7 @@ class PluginCreditTicketConfig extends CommonDBTM
                 'display'     => false,
                 'value'       => $ticket->input['plugin_credit_entities_id_followups'] ??
                                  $ticket_config->fields['plugin_credit_entities_id_followups'] ?? 0,
-                'condition'   => PluginCreditEntity::getActiveFilter(),
+                'condition'   => PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type']),
                 'comments'    => false,
                 'rand'        => $rand,
                 'width'       => $embed_in_ticket_form ? '100%' : '',
@@ -142,7 +147,7 @@ class PluginCreditTicketConfig extends CommonDBTM
                 'display'     => false,
                 'value'       => $ticket->input['plugin_credit_entities_id_tasks'] ??
                                  $ticket_config->fields['plugin_credit_entities_id_tasks'] ?? 0,
-                'condition'   => PluginCreditEntity::getActiveFilter(),
+                'condition'   => PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type']),
                 'comments'    => false,
                 'rand'        => $rand,
                 'width'       => $embed_in_ticket_form ? '100%' : '',
@@ -156,7 +161,7 @@ class PluginCreditTicketConfig extends CommonDBTM
                 'display'     => false,
                 'value'       => $ticket->input['plugin_credit_entities_id_solutions'] ??
                                  $ticket_config->fields['plugin_credit_entities_id_solutions'] ?? 0,
-                'condition'   => PluginCreditEntity::getActiveFilter(),
+                'condition'   => PluginCreditEntity::getActiveFilterForTicketType($ticket->fields['type']),
                 'comments'    => false,
                 'rand'        => $rand,
                 'width'       => $embed_in_ticket_form ? '100%' : '',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Hi, 

We would like to add a new option to the credit plugin. We would like to be able to enable or disable credit visibility depending on the ticket type.

Here is an example : 

![image](https://github.com/user-attachments/assets/80e776b0-51eb-4deb-b32c-bc8ea33a7b74)

In this configuration, this credit will be selectable on an incident type ticket:

![image](https://github.com/user-attachments/assets/c37276d9-ec2c-4bb2-a053-e37195334071)

But will not be available for a request type ticket:

![image](https://github.com/user-attachments/assets/8887df60-7bf6-4394-8107-62d1646d5fa5)

N.B. I haven't added the translations

Anthony from IT Gouvernance
