### PR TITLE
FIX / Consumed credits visibility on tickets for read-only users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [unreleased] -
+## [Unreleased]
 
 ### Fixed
 
-- Fix possibility to set 0 credit used when adding a follow-up, a task, or a solution
+- Show credit vouchers list in entity tab for read-only users while keeping add/config forms restricted to editable contexts.
 
 ## [1.15.2] - 2025-12-22
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -167,7 +167,7 @@ class PluginCreditEntity extends CommonDBTM
 
         $canedit = $itemtype === 'Entity' && $entity->canEdit($ID);
 
-        if ($itemtype === 'Entity') {
+        if ($itemtype === 'Entity' && $canedit) {
             PluginCreditEntityConfig::showEntityConfigForm($entity->getID());
         }
 
@@ -244,7 +244,7 @@ class PluginCreditEntity extends CommonDBTM
             'itemtype'         => PluginCreditEntity::class,
         ];
 
-        if ($itemtype === 'Entity' && $canedit) {
+        if ($itemtype === 'Entity') {
             TemplateRenderer::getInstance()->display('@credit/creditentity.hmtl.twig', [
                 'form_url'              => self::getFormUrl(),
                 'credittypeclass'       => PluginCreditType::class,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -220,16 +220,18 @@ class PluginCreditTicket extends CommonDBTM
 
         $entries = [];
 
-        if ($number && $canedit) {
-            $massiveactionparams = [
-                'num_displayed'    => min($number, $_SESSION['glpilist_limit']),
-                'container'        => 'mass' . self::class . $rand,
-                'itemtype'         => PluginCreditTicket::class,
-                'specific_actions' => [
-                    'update'    => _x('button', 'Update'),
-                    'purge'     => _x('button', 'Delete permanently'),
-                ],
-            ];
+        if ($number) {
+            if ($canedit) {
+                $massiveactionparams = [
+                    'num_displayed'    => min($number, $_SESSION['glpilist_limit']),
+                    'container'        => 'mass' . self::class . $rand,
+                    'itemtype'         => PluginCreditTicket::class,
+                    'specific_actions' => [
+                        'update'    => _x('button', 'Update'),
+                        'purge'     => _x('button', 'Delete permanently'),
+                    ],
+                ];
+            }
             foreach (self::getAllForTicket($ID) as $data) {
                 $credit_entity = new PluginCreditEntity();
                 $credit_entity->getFromDB($data['plugin_credit_entities_id']);

--- a/templates/creditentity.hmtl.twig
+++ b/templates/creditentity.hmtl.twig
@@ -30,6 +30,7 @@
 {% import "components/form/fields_macros.html.twig" as fields %}
 
 {% set rand = random() %}
+{% if canedit %}
 <div name="firstbloc" id="firstbloc" class="">
     <form name="creditentity_form{{ rand }}" id="creditentity_form{{ rand }}" method="post" action="{{ form_url }}">
         <input type="hidden" name="_glpi_csrf_token" value="{{ csrf_token() }}" />
@@ -121,6 +122,7 @@
         <div class="hr mt-3 mb-3"></div>
     </form>
 </div>
+{% endif %}
 <div name="secondbloc" id="secondbloc" class="mb-5">
     {% set datatable_params = {
         'is_tab': true,

--- a/templates/tickets/form.html.twig
+++ b/templates/tickets/form.html.twig
@@ -48,7 +48,7 @@
                         {
                             'entity': entity_id,
                             'condition': conditions,
-                            'on_change': 'getQuantityRemainingForm(this.value);',
+                            'on_change': 'getQuantityRemainingForm' ~ rand ~ '(this.value, this);',
                             'field_class': 'col-4 col-sm-4',
                         }
                     ) }}
@@ -68,17 +68,27 @@
                     ) }}
 
                     <script>
-                        function getQuantityRemainingForm(val) {
-                            var formblock = document.querySelector('.formblock');
-                            var quantity = formblock.querySelector('[id*="plugin_credit_quantity"]');
-                            var quantity_field = quantity.closest('.col-4');
-                            var quantity_label = formblock.querySelector('[for*="plugin_credit_quantity"]');
+                        function getQuantityRemainingForm{{ rand }}(val, source) {
+                            var form = source ? source.closest('form') : document.getElementById('creditentity_form{{ rand }}');
+                            if (!form) {
+                                return;
+                            }
+
+                            var quantity = form.querySelector('[id*="plugin_credit_quantity"]');
+                            var quantity_label = form.querySelector('[for*="plugin_credit_quantity"]');
+                            if (!quantity || !quantity_label) {
+                                return;
+                            }
+
+                            var form_help = quantity_label.querySelector('span.form-help');
+                            if (!form_help) {
+                                return;
+                            }
 
                             if (val == 0) {
-                                quantity_field.classList.add('d-none');
-                                quantity.value = 1;
-                                quantity_label.querySelector('span.form-help').setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : 0 ');
-                                quantity_label.querySelector('span.form-help').setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : 0 ');
+                                quantity.value = 0;
+                                form_help.setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : 0 ');
+                                form_help.setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : 0 ');
                             } else {
                                 quantity_field.classList.remove('d-none');
                                 $.ajax({
@@ -89,9 +99,9 @@
                                     }
                                 }).done(function (data) {
                                     quantity.max = data;
-                                    quantity.value = 1;
-                                    quantity_label.querySelector('span.form-help').setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
-                                    quantity_label.querySelector('span.form-help').setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
+                                    quantity.value = 0;
+                                    form_help.setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
+                                    form_help.setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
                                 });
                             }
                         }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

- It fixes !42948
- After upgrading from GLPI 10 to GLPI 11.0.6, technician profiles (with plugin rights enabled) could no longer reliably see consumed credits on tickets. Consumed credits rendering was coupled with ticket editability (canedit), which could hide data in read-only contexts. In addition, the credit form JavaScript used broad DOM targeting, making it sensitive to Twig render order and page structure.
