### PR TITLE
Bugfix: Validation consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improve consumed credits modal readability and open related tickets in a new tab
 - Show credit vouchers list in entity tab for read-only users while keeping add/config forms restricted to editable contexts.
-- Centralize credit consumption validation, prevent invalid voucher selections outside the validity window, and fix the ticket tab quantity field behavior.
+- Improve credit validation and voucher handling.
 
 ## [1.15.2] - 2025-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improve consumed credits modal readability and open related tickets in a new tab
 - Show credit vouchers list in entity tab for read-only users while keeping add/config forms restricted to editable contexts.
+- Centralize credit consumption validation, prevent invalid voucher selections outside the validity window, and fix the ticket tab quantity field behavior.
 
 ## [1.15.2] - 2025-12-22
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -50,7 +50,7 @@ if (isset($_POST["add"])) {
         );
     }
 
-    Html::back();
 }
+Html::back();
 
 throw new BadRequestHttpException();

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -29,55 +29,27 @@
  * -------------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkRight("ticket", UPDATE);
-Session::checkRightsOr(PluginCreditTicketConfig::$rightname, [PluginCreditTicketConfig::TICKET_TAB, PluginCreditTicketConfig::TICKET_TAB]);
-
-$ticket = new Ticket();
-if (!$ticket->getFromDB((int) $_REQUEST['tickets_id'])) {
-    throw new AccessDeniedHttpException(
-        'Ticket not found.',
-    );
-}
+Session::checkRight(\Ticket::class, UPDATE);
 
 $PluginCreditTicket = new PluginCreditTicket();
-if ($_REQUEST['plugin_credit_entities_id'] == 0) {
-    Session::addMessageAfterRedirect(
-        __s('Credit voucher entity must be selected.', 'credit'),
-        true,
-        ERROR,
-    );
-    Html::back();
-} elseif ($_REQUEST['plugin_credit_quantity'] == 0) {
-    Session::addMessageAfterRedirect(
-        __s('Credit voucher quantity must be greater than 0.', 'credit'),
-        true,
-        ERROR,
-    );
-    Html::back();
-}
+if (isset($_POST["add"])) {
+    $input = [
+        'tickets_id'                => $_POST['tickets_id'] ?? null,
+        'plugin_credit_entities_id' => $_POST['plugin_credit_entities_id'] ?? null,
+        'consumed'                  => $_POST['plugin_credit_quantity'] ?? null,
+        'users_id'                  => Session::getLoginUserID(),
+    ];
 
-if (Session::haveAccessToEntity($_REQUEST['plugin_credit_entities_id'])) {
-    throw new AccessDeniedHttpException();
-}
+    if ($PluginCreditTicket->add($input)) {
+        Session::addMessageAfterRedirect(
+            __s('Credit voucher successfully added.', 'credit'),
+            true,
+            INFO,
+        );
+    }
 
-
-$input = [
-    'tickets_id'                => $_REQUEST['tickets_id'],
-    'plugin_credit_entities_id' => $_REQUEST['plugin_credit_entities_id'],
-    'consumed'                  => $_REQUEST['plugin_credit_quantity'],
-    'users_id'                  => Session::getLoginUserID(),
-];
-
-
-if ($PluginCreditTicket->add($input)) {
-    Session::addMessageAfterRedirect(
-        __s('Credit voucher successfully added.', 'credit'),
-        true,
-        INFO,
-    );
     Html::back();
 }
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -31,7 +31,7 @@
 
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkRight(Ticket::class, UPDATE);
+Session::checkRight(\Ticket::class, UPDATE);
 
 $PluginCreditTicket = new PluginCreditTicket();
 if (isset($_POST["add"])) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -31,7 +31,7 @@
 
 use Glpi\Exception\Http\BadRequestHttpException;
 
-Session::checkRight(\Ticket::class, UPDATE);
+Session::checkRight(Ticket::class, UPDATE);
 
 $PluginCreditTicket = new PluginCreditTicket();
 if (isset($_POST["add"])) {

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -602,14 +602,29 @@ SQL;
         global $DB;
         return [
             'glpi_plugin_credit_entities.is_active' => 1,
-            'OR' => [
-                'glpi_plugin_credit_entities.end_date' => null,
-                new QueryExpression(
-                    sprintf(
-                        'NOW() < %s',
-                        $DB->quoteName('glpi_plugin_credit_entities.end_date'),
-                    ),
-                ),
+            'AND' => [
+                [
+                    'OR' => [
+                        'glpi_plugin_credit_entities.begin_date' => null,
+                        new QueryExpression(
+                            sprintf(
+                                '%s <= NOW()',
+                                $DB->quoteName('glpi_plugin_credit_entities.begin_date'),
+                            ),
+                        ),
+                    ],
+                ],
+                [
+                    'OR' => [
+                        'glpi_plugin_credit_entities.end_date' => null,
+                        new QueryExpression(
+                            sprintf(
+                                'NOW() <= %s',
+                                $DB->quoteName('glpi_plugin_credit_entities.end_date'),
+                            ),
+                        ),
+                    ],
+                ],
             ],
         ];
     }
@@ -624,9 +639,13 @@ SQL;
             'FROM'   => 'glpi_plugin_credit_entities',
             'WHERE'  => [
                 'id' => $credit_id,
-            ],
+            ] + self::getActiveFilter(),
         ];
         $entity_result = $DB->request($entity_query)->current();
+        if ($entity_result === false) {
+            return 0;
+        }
+
         $overconsumption_allowed = $entity_result['overconsumption_allowed'];
         $quantity_sold           = (int) $entity_result['quantity'];
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -190,6 +190,203 @@ class PluginCreditTicket extends CommonDBTM
         return $tot;
     }
 
+    private static function canUpdateCreditsForTicket(Ticket $ticket): bool
+    {
+        if (Session::haveRight(Entity::$rightname, UPDATE)) {
+            return true;
+        }
+
+        return $ticket->canEdit($ticket->getID())
+            && !in_array($ticket->fields['status'], array_merge(Ticket::getSolvedStatusArray(), Ticket::getClosedStatusArray()));
+    }
+
+    private static function getValidatedConsumptionInput(int $ticket_id, int $credit_id, int $consumed, ?self $current_credit = null): array|false
+    {
+        $ticket = new Ticket();
+        if (
+            !$ticket->getFromDB($ticket_id)
+            || !$ticket->can($ticket_id, READ)
+            || !self::canUpdateCreditsForTicket($ticket)
+        ) {
+            Session::addMessageAfterRedirect(
+                __s('You do not have rights to update credit vouchers for this ticket.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $credit_entity = new PluginCreditEntity();
+        $credit_criteria = getEntitiesRestrictCriteria('', '', $ticket->getEntityID(), true);
+        $credit_criteria['id'] = $credit_id;
+        $credit_criteria += PluginCreditEntity::getActiveFilter();
+
+        if (!$credit_entity->getFromDBByCrit($credit_criteria)) {
+            Session::addMessageAfterRedirect(
+                __s('Selected credit voucher is not available for this ticket.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $quantity_sold = (int) $credit_entity->fields['quantity'];
+        $quantity_consumed = self::getConsumedForCreditEntity($credit_entity->getID());
+
+        if (
+            $current_credit instanceof self
+            && (int) $current_credit->fields['plugin_credit_entities_id'] === $credit_entity->getID()
+        ) {
+            $quantity_consumed = max(0, $quantity_consumed - (int) $current_credit->fields['consumed']);
+        }
+
+        $quantity_remaining = max(0, $quantity_sold - $quantity_consumed);
+
+        if (0 !== $quantity_sold && $quantity_remaining < $consumed) {
+            $message = sprintf(
+                __s('Quantity consumed exceeds remaining credits: %d', 'credit'),
+                $quantity_remaining,
+            );
+
+            if ($credit_entity->getField('overconsumption_allowed')) {
+                Session::addMessageAfterRedirect($message, true, WARNING);
+            } else {
+                Session::addMessageAfterRedirect($message, true, ERROR);
+                return false;
+            }
+        }
+
+        return [
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $credit_entity->getID(),
+            'consumed'                  => $consumed,
+        ];
+    }
+
+    public function prepareInputForAdd($input)
+    {
+        $ticket_id = filter_var(
+            $input['tickets_id'] ?? null,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($ticket_id === false) {
+            Session::addMessageAfterRedirect(
+                __s('Ticket is mandatory.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $credit_id = filter_var(
+            $input['plugin_credit_entities_id'] ?? null,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($credit_id === false) {
+            Session::addMessageAfterRedirect(
+                __s('Credit voucher entity must be selected.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $consumed = filter_var(
+            $input['consumed'] ?? null,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($consumed === false) {
+            Session::addMessageAfterRedirect(
+                __s('Credit voucher quantity must be greater than 0.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $validated_input = self::getValidatedConsumptionInput($ticket_id, $credit_id, $consumed);
+        if ($validated_input === false) {
+            return false;
+        }
+
+        $input = $validated_input + $input;
+        $input['users_id'] = (int) Session::getLoginUserID();
+
+        return $input;
+    }
+
+    public function prepareInputForUpdate($input)
+    {
+        $credit = new self();
+        if (
+            !isset($input['id'])
+            || filter_var($input['id'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]) === false
+            || !$credit->getFromDB((int) $input['id'])
+        ) {
+            Session::addMessageAfterRedirect(
+                __s('Unable to find the requested credit consumption.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $ticket_id = filter_var(
+            $input['tickets_id'] ?? $credit->fields['tickets_id'],
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($ticket_id === false) {
+            Session::addMessageAfterRedirect(
+                __s('Ticket is mandatory.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $credit_id = filter_var(
+            $input['plugin_credit_entities_id'] ?? $credit->fields['plugin_credit_entities_id'],
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($credit_id === false) {
+            Session::addMessageAfterRedirect(
+                __s('Credit voucher entity must be selected.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $consumed = filter_var(
+            $input['consumed'] ?? $credit->fields['consumed'],
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($consumed === false) {
+            Session::addMessageAfterRedirect(
+                __s('Credit voucher quantity must be greater than 0.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $validated_input = self::getValidatedConsumptionInput($ticket_id, $credit_id, $consumed, $credit);
+        if ($validated_input === false) {
+            return false;
+        }
+
+        $input = $validated_input + $input;
+        $input['users_id'] = $credit->fields['users_id'];
+
+        return $input;
+    }
+
     /**
      * Show credit vouchers consumed for a ticket
      *
@@ -205,15 +402,7 @@ class PluginCreditTicket extends CommonDBTM
             return false;
         }
 
-        $canedit = false;
-        if (Session::haveRight(Entity::$rightname, UPDATE)) {
-            $canedit = true; // Entity admin has always right to update credits
-        } elseif (
-            $ticket->canEdit($ID)
-            && !in_array($ticket->fields['status'], array_merge(Ticket::getSolvedStatusArray(), Ticket::getClosedStatusArray()))
-        ) {
-            $canedit = true;
-        }
+        $canedit = self::canUpdateCreditsForTicket($ticket);
 
         $number = self::countForItem($ticket);
         $rand   = mt_rand();
@@ -480,44 +669,13 @@ class PluginCreditTicket extends CommonDBTM
             return;
         }
 
-        $credit_ticket = new self();
-
-        $credit_entity = new PluginCreditEntity();
-        $credit_entity->getFromDB($item->input['plugin_credit_entities_id']);
-
-        $quantity_sold      = (int) $credit_entity->fields['quantity'];
-        $quantity_consumed  = $credit_ticket->getConsumedForCreditEntity($item->input['plugin_credit_entities_id']);
-        $quantity_remaining = max(0, $quantity_sold - $quantity_consumed);
-
-        if (0 !== $quantity_sold && $quantity_remaining < $item->input['plugin_credit_quantity']) {
-            if ($credit_entity->getField('overconsumption_allowed')) {
-                Session::addMessageAfterRedirect(
-                    sprintf(
-                        __s('Quantity consumed exceeds remaining credits: %d', 'credit'),
-                        $quantity_remaining,
-                    ),
-                    true,
-                    WARNING,
-                );
-            } else {
-                Session::addMessageAfterRedirect(
-                    sprintf(
-                        __s('Quantity consumed exceeds remaining credits: %d', 'credit'),
-                        $quantity_remaining,
-                    ),
-                    true,
-                    ERROR,
-                );
-                return;
-            }
-        }
-
         $input = [
             'tickets_id'                => $ticket->getID(),
-            'plugin_credit_entities_id' => $item->input['plugin_credit_entities_id'],
-            'consumed'                  => $item->input['plugin_credit_quantity'],
+            'plugin_credit_entities_id' => $item->input['plugin_credit_entities_id'] ?? null,
+            'consumed'                  => $item->input['plugin_credit_quantity'] ?? null,
             'users_id'                  => Session::getLoginUserID(),
         ];
+        $credit_ticket = new self();
         if ($credit_ticket->add($input)) {
             Session::addMessageAfterRedirect(
                 __s('Credit voucher successfully added.', 'credit'),

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -200,7 +200,7 @@ class PluginCreditTicket extends CommonDBTM
             && !in_array($ticket->fields['status'], array_merge(Ticket::getSolvedStatusArray(), Ticket::getClosedStatusArray()));
     }
 
-    private static function checkInput(array $input, ?self $current_credit = null): array|false
+    private static function checkInput(array $input, ?self $current_credit = null, bool $skip_status_check = false): array|false
     {
         $ticket_id = filter_var(
             $input['tickets_id'] ?? null,
@@ -248,7 +248,7 @@ class PluginCreditTicket extends CommonDBTM
         if (
             !$ticket->getFromDB($ticket_id)
             || !$ticket->can($ticket_id, READ)
-            || !self::canUpdateCreditsForTicket($ticket)
+            || (!$skip_status_check && !self::canUpdateCreditsForTicket($ticket))
         ) {
             Session::addMessageAfterRedirect(
                 __s('You do not have rights to update credit vouchers for this ticket.', 'credit'),
@@ -307,13 +307,15 @@ class PluginCreditTicket extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-        $validated_input = self::checkInput($input);
+        $skip_status_check = (bool) ($input['_skip_status_check'] ?? false);
+        unset($input['_skip_status_check']);
+
+        $validated_input = self::checkInput($input, null, $skip_status_check);
         if ($validated_input === false) {
             return false;
         }
 
         $input = $validated_input + $input;
-        $input['users_id'] = (int) Session::getLoginUserID();
 
         return $input;
     }
@@ -638,6 +640,7 @@ class PluginCreditTicket extends CommonDBTM
             'plugin_credit_entities_id' => $item->input['plugin_credit_entities_id'] ?? null,
             'consumed'                  => $item->input['plugin_credit_quantity'] ?? null,
             'users_id'                  => Session::getLoginUserID(),
+            '_skip_status_check'        => true,
         ];
         $credit_ticket = new self();
         if ($credit_ticket->add($input)) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -200,8 +200,50 @@ class PluginCreditTicket extends CommonDBTM
             && !in_array($ticket->fields['status'], array_merge(Ticket::getSolvedStatusArray(), Ticket::getClosedStatusArray()));
     }
 
-    private static function getValidatedConsumptionInput(int $ticket_id, int $credit_id, int $consumed, ?self $current_credit = null): array|false
+    private static function checkInput(array $input, ?self $current_credit = null): array|false
     {
+        $ticket_id = filter_var(
+            $input['tickets_id'] ?? null,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($ticket_id === false) {
+            Session::addMessageAfterRedirect(
+                __s('Ticket is mandatory.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $credit_id = filter_var(
+            $input['plugin_credit_entities_id'] ?? null,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($credit_id === false) {
+            Session::addMessageAfterRedirect(
+                __s('Credit voucher entity must be selected.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
+        $consumed = filter_var(
+            $input['consumed'] ?? null,
+            FILTER_VALIDATE_INT,
+            ['options' => ['min_range' => 1]],
+        );
+        if ($consumed === false) {
+            Session::addMessageAfterRedirect(
+                __s('Credit voucher quantity must be greater than 0.', 'credit'),
+                true,
+                ERROR,
+            );
+            return false;
+        }
+
         $ticket = new Ticket();
         if (
             !$ticket->getFromDB($ticket_id)
@@ -265,49 +307,7 @@ class PluginCreditTicket extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-        $ticket_id = filter_var(
-            $input['tickets_id'] ?? null,
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 1]],
-        );
-        if ($ticket_id === false) {
-            Session::addMessageAfterRedirect(
-                __s('Ticket is mandatory.', 'credit'),
-                true,
-                ERROR,
-            );
-            return false;
-        }
-
-        $credit_id = filter_var(
-            $input['plugin_credit_entities_id'] ?? null,
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 1]],
-        );
-        if ($credit_id === false) {
-            Session::addMessageAfterRedirect(
-                __s('Credit voucher entity must be selected.', 'credit'),
-                true,
-                ERROR,
-            );
-            return false;
-        }
-
-        $consumed = filter_var(
-            $input['consumed'] ?? null,
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 1]],
-        );
-        if ($consumed === false) {
-            Session::addMessageAfterRedirect(
-                __s('Credit voucher quantity must be greater than 0.', 'credit'),
-                true,
-                ERROR,
-            );
-            return false;
-        }
-
-        $validated_input = self::getValidatedConsumptionInput($ticket_id, $credit_id, $consumed);
+        $validated_input = self::checkInput($input);
         if ($validated_input === false) {
             return false;
         }
@@ -334,49 +334,13 @@ class PluginCreditTicket extends CommonDBTM
             return false;
         }
 
-        $ticket_id = filter_var(
-            $input['tickets_id'] ?? $credit->fields['tickets_id'],
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 1]],
-        );
-        if ($ticket_id === false) {
-            Session::addMessageAfterRedirect(
-                __s('Ticket is mandatory.', 'credit'),
-                true,
-                ERROR,
-            );
-            return false;
-        }
+        $input += [
+            'tickets_id'                => $credit->fields['tickets_id'],
+            'plugin_credit_entities_id' => $credit->fields['plugin_credit_entities_id'],
+            'consumed'                  => $credit->fields['consumed'],
+        ];
 
-        $credit_id = filter_var(
-            $input['plugin_credit_entities_id'] ?? $credit->fields['plugin_credit_entities_id'],
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 1]],
-        );
-        if ($credit_id === false) {
-            Session::addMessageAfterRedirect(
-                __s('Credit voucher entity must be selected.', 'credit'),
-                true,
-                ERROR,
-            );
-            return false;
-        }
-
-        $consumed = filter_var(
-            $input['consumed'] ?? $credit->fields['consumed'],
-            FILTER_VALIDATE_INT,
-            ['options' => ['min_range' => 1]],
-        );
-        if ($consumed === false) {
-            Session::addMessageAfterRedirect(
-                __s('Credit voucher quantity must be greater than 0.', 'credit'),
-                true,
-                ERROR,
-            );
-            return false;
-        }
-
-        $validated_input = self::getValidatedConsumptionInput($ticket_id, $credit_id, $consumed, $credit);
+        $validated_input = self::checkInput($input, $credit);
         if ($validated_input === false) {
             return false;
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true">
+   <testsuites>
+      <testsuite name="Credit plugin tests">
+         <directory>tests</directory>
+      </testsuite>
+   </testsuites>
+</phpunit>

--- a/templates/tickets/form.html.twig
+++ b/templates/tickets/form.html.twig
@@ -86,11 +86,15 @@
                             }
 
                             if (val == 0) {
+                                quantity.closest('.form-field').classList.add('d-none');
+                                quantity.disabled = true;
+                                quantity.max = 0;
                                 quantity.value = 0;
                                 form_help.setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : 0 ');
                                 form_help.setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : 0 ');
                             } else {
                                 quantity.closest('.form-field').classList.remove('d-none');
+                                quantity.disabled = false;
                                 $.ajax({
                                     type: 'POST',
                                     url: '{{ path('plugins/credit/ajax/dropdownQuantity.php') }}',

--- a/tests/TicketTest.php
+++ b/tests/TicketTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Credit plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Credit.
+ *
+ * Credit is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Credit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Credit. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @author    François Legastelois
+ * @copyright Copyright (C) 2017-2023 by Credit plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/credit
+ * -------------------------------------------------------------------------
+ */
+
+use Glpi\Tests\DbTestCase;
+
+class PluginCreditTicketTest extends DbTestCase
+{
+    private function createTicket(array $extra = []): Ticket
+    {
+        return $this->createItem(Ticket::class, array_merge([
+            'name'        => 'Credit test ticket',
+            'content'     => 'Credit test content',
+            'entities_id' => 0,
+        ], $extra));
+    }
+
+    private function createCreditVoucher(array $extra = []): PluginCreditEntity
+    {
+        return $this->createItem(PluginCreditEntity::class, array_merge([
+            'name'                    => 'Credit test voucher',
+            'entities_id'             => 0,
+            'is_active'               => 1,
+            'quantity'                => 10,
+            'overconsumption_allowed' => 0,
+            'low_credit_alert'        => -1,
+        ], $extra));
+    }
+
+    public function testConsumeVoucherOnSolvedTicketFromSolutionHook(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $tech = new User();
+        $this->assertTrue($tech->getFromDBByCrit(['name' => 'tech']));
+
+        $ticket = $this->createTicket();
+        $credit = $this->createCreditVoucher();
+
+        $this->createItem(Ticket_User::class, [
+            'tickets_id' => $ticket->getID(),
+            'users_id'   => $tech->getID(),
+            'type'       => CommonITILActor::ASSIGN,
+        ]);
+
+        $this->assertTrue($ticket->update([
+            'id'     => $ticket->getID(),
+            'status' => CommonITILObject::SOLVED,
+        ]));
+
+        $this->login('tech', 'tech');
+
+        $solution = new ITILSolution();
+        $solution->fields = [
+            'itemtype' => Ticket::class,
+            'items_id' => $ticket->getID(),
+        ];
+        $solution->input = [
+            'plugin_credit_consumed_voucher' => 1,
+            'plugin_credit_entities_id'      => $credit->getID(),
+            'plugin_credit_quantity'         => 1,
+        ];
+
+        PluginCreditTicket::consumeVoucher($solution);
+
+        $this->assertSame(1, countElementsInTable(PluginCreditTicket::getTable(), [
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $credit->getID(),
+            'consumed'                  => 1,
+            'users_id'                  => $tech->getID(),
+        ]));
+    }
+
+    public function testPrepareInputForAddRejectsOutOfWindowVouchers(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ticket = $this->createTicket();
+        $future_credit = $this->createCreditVoucher([
+            'name'       => 'Future credit test voucher',
+            'begin_date' => date('Y-m-d', strtotime('+1 day')),
+        ]);
+        $expired_credit = $this->createCreditVoucher([
+            'name'     => 'Expired credit test voucher',
+            'end_date' => date('Y-m-d', strtotime('-1 day')),
+        ]);
+
+        $credit_ticket = new PluginCreditTicket();
+
+        $this->assertFalse($credit_ticket->prepareInputForAdd([
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $future_credit->getID(),
+            'consumed'                  => 1,
+            'users_id'                  => Session::getLoginUserID(),
+        ]));
+
+        $this->assertFalse($credit_ticket->prepareInputForAdd([
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $expired_credit->getID(),
+            'consumed'                  => 1,
+            'users_id'                  => Session::getLoginUserID(),
+        ]));
+    }
+}

--- a/tests/TicketTest.php
+++ b/tests/TicketTest.php
@@ -105,11 +105,11 @@ class PluginCreditTicketTest extends DbTestCase
         $ticket = $this->createTicket();
         $future_credit = $this->createCreditVoucher([
             'name'       => 'Future credit test voucher',
-            'begin_date' => date('Y-m-d', strtotime('+1 day')),
+            'begin_date' => date('Y-m-d 00:00:00', strtotime('+1 day')),
         ]);
         $expired_credit = $this->createCreditVoucher([
             'name'     => 'Expired credit test voucher',
-            'end_date' => date('Y-m-d', strtotime('-1 day')),
+            'end_date' => date('Y-m-d 23:59:59', strtotime('-1 day')),
         ]);
 
         $credit_ticket = new PluginCreditTicket();

--- a/tests/TicketTest.php
+++ b/tests/TicketTest.php
@@ -130,4 +130,74 @@ class PluginCreditTicketTest extends DbTestCase
             'users_id'                  => Session::getLoginUserID(),
         ]));
     }
+
+    public function testPrepareInputForAddAllowsOverconsumptionWhenAllowed(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ticket = $this->createTicket();
+        $credit = $this->createCreditVoucher([
+            'quantity'                => 1,
+            'overconsumption_allowed' => 1,
+        ]);
+
+        $credit_ticket = new PluginCreditTicket();
+
+        $input = $credit_ticket->prepareInputForAdd([
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $credit->getID(),
+            'consumed'                  => 2,
+            'users_id'                  => Session::getLoginUserID(),
+        ]);
+
+        $this->assertIsArray($input);
+        $this->hasSessionMessages(WARNING, ['Quantity consumed exceeds remaining credits: 1']);
+    }
+
+    public function testPrepareInputForAddRejectsOverconsumptionWhenNotAllowed(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ticket = $this->createTicket();
+        $credit = $this->createCreditVoucher([
+            'quantity'                => 1,
+            'overconsumption_allowed' => 0,
+        ]);
+
+        $credit_ticket = new PluginCreditTicket();
+
+        $this->assertFalse($credit_ticket->prepareInputForAdd([
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $credit->getID(),
+            'consumed'                  => 2,
+            'users_id'                  => Session::getLoginUserID(),
+        ]));
+        $this->hasSessionMessages(ERROR, ['Quantity consumed exceeds remaining credits: 1']);
+    }
+
+    public function testPrepareInputForUpdateWithinAdjustedRemainingBudget(): void
+    {
+        $this->login('glpi', 'glpi');
+
+        $ticket = $this->createTicket();
+        $credit = $this->createCreditVoucher(['quantity' => 5]);
+
+        $credit_ticket = new PluginCreditTicket();
+        $this->assertGreaterThan(0, (int) $credit_ticket->add([
+            'tickets_id'                => $ticket->getID(),
+            'plugin_credit_entities_id' => $credit->getID(),
+            'consumed'                  => 3,
+            'users_id'                  => Session::getLoginUserID(),
+        ]));
+
+        // Total consumed for the voucher (3) already accounts for this record, so
+        // updating it to 4 must be validated against the budget with the previous
+        // 3 deducted (5 - 0 = 5 remaining), not against the raw total (5 - 3 = 2).
+        $this->assertTrue($credit_ticket->update([
+            'id'       => $credit_ticket->getID(),
+            'consumed' => 4,
+        ]));
+
+        $this->assertSame(4, (int) $credit_ticket->fields['consumed']);
+    }
 }

--- a/tests/TicketTest.php
+++ b/tests/TicketTest.php
@@ -44,14 +44,16 @@ class PluginCreditTicketTest extends DbTestCase
 
     private function createCreditVoucher(array $extra = []): PluginCreditEntity
     {
-        return $this->createItem(PluginCreditEntity::class, array_merge([
+        $input = array_merge([
             'name'                    => 'Credit test voucher',
             'entities_id'             => 0,
             'is_active'               => 1,
             'quantity'                => 10,
             'overconsumption_allowed' => 0,
             'low_credit_alert'        => -1,
-        ], $extra));
+        ], $extra);
+
+        return $this->createItem(PluginCreditEntity::class, $input, ['begin_date', 'end_date']);
     }
 
     public function testConsumeVoucherOnSolvedTicketFromSolutionHook(): void
@@ -105,11 +107,11 @@ class PluginCreditTicketTest extends DbTestCase
         $ticket = $this->createTicket();
         $future_credit = $this->createCreditVoucher([
             'name'       => 'Future credit test voucher',
-            'begin_date' => date('Y-m-d 00:00:00', strtotime('+1 day')),
+            'begin_date' => date('Y-m-d', strtotime('+1 day')),
         ]);
         $expired_credit = $this->createCreditVoucher([
             'name'     => 'Expired credit test voucher',
-            'end_date' => date('Y-m-d 23:59:59', strtotime('-1 day')),
+            'end_date' => date('Y-m-d', strtotime('-1 day')),
         ]);
 
         $credit_ticket = new PluginCreditTicket();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,4 +29,4 @@
  * -------------------------------------------------------------------------
  */
 
-$loader = require dirname(__DIR__, 3) . '/vendor/autoload.php';
+require dirname(__DIR__, 3) . '/tests/bootstrap.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Credit plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Credit.
+ *
+ * Credit is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Credit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Credit. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @author    François Legastelois
+ * @copyright Copyright (C) 2017-2023 by Credit plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/credit
+ * -------------------------------------------------------------------------
+ */
+
+$loader = require dirname(__DIR__, 3) . '/vendor/autoload.php';


### PR DESCRIPTION
## Checklist before requesting a review

  - [x] I have performed a self-review of my code.
  - [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
  - [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.

  ## Description

  This PR centralizes credit consumption validation so both the manual ticket form and the hook-driven followup/task/solution flow
  use the same server-side rules. It also prevents selecting vouchers outside their valid begin/end date window and fixes the
  ticket-tab JavaScript that broke the quantity field when selecting a voucher.

  Validation performed:
  - `find inc front ajax -name '*.php' -print0 | xargs -0 -n1 php -l`
  - `git diff --check`
  - Manual UI validation of voucher selection and quantity behavior in the ticket form