### PR TITLE
Fix of the minimum quantity of consumable credits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased] -
+
+### Fixed
+
+- Fixed the minimum consumable quantity at 1
+
 ## [1.15.3] - 2026-04-29
 
 ### Fixed

--- a/templates/tickets/form.html.twig
+++ b/templates/tickets/form.html.twig
@@ -90,7 +90,7 @@
                                 form_help.setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : 0 ');
                                 form_help.setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : 0 ');
                             } else {
-                                quantity_field.classList.remove('d-none');
+                                quantity.closest('.form-field').classList.remove('d-none');
                                 $.ajax({
                                     type: 'POST',
                                     url: '{{ path('plugins/credit/ajax/dropdownQuantity.php') }}',
@@ -99,7 +99,7 @@
                                     }
                                 }).done(function (data) {
                                     quantity.max = data;
-                                    quantity.value = 0;
+                                    quantity.value = 1;
                                     form_help.setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
                                     form_help.setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
                                 });


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43309
- Here is a brief description of what this PR does
In the “Credit Voucher” tab, it was no longer possible to add one manually due to a JavaScript error; furthermore, the minimum quantity was always 0 instead of 1.

## Screenshots (if appropriate):
