### PR TITLE
feat: automate credit point calculation from task duration and rate s…

### DIFF
--- a/ajax/calculatePoints.php
+++ b/ajax/calculatePoints.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Credit plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Credit.
+ *
+ * Credit is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Credit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Credit. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @author    François Legastelois
+ * @copyright Copyright (C) 2017-2023 by Credit plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/credit
+ * -------------------------------------------------------------------------
+ */
+
+/**
+ * AJAX endpoint: calculate credit points from task duration and selected bareme.
+ *
+ * POST parameters:
+ *   duration_seconds  int   Task duration in seconds
+ *   bareme_id         int   PluginCreditBareme id
+ *
+ * Returns the integer number of points (JSON).
+ */
+
+include('../../../inc/includes.php');
+
+$plugin = new Plugin();
+if (!$plugin->isActivated('credit')) {
+    Http::notFound();
+}
+
+Session::checkLoginUser();
+
+$duration_seconds = (int) ($_POST['duration_seconds'] ?? 0);
+$bareme_id        = (int) ($_POST['bareme_id'] ?? 0);
+
+header('Content-Type: application/json');
+echo json_encode(PluginCreditBareme::calculatePoints($duration_seconds, $bareme_id));

--- a/hook.php
+++ b/hook.php
@@ -120,7 +120,10 @@ function plugin_credit_uninstall()
  */
 function plugin_credit_getDropdown()
 {
-    return ['PluginCreditType' => PluginCreditType::getTypeName(Session::getPluralNumber())];
+    return [
+        'PluginCreditType'   => PluginCreditType::getTypeName(Session::getPluralNumber()),
+        'PluginCreditBareme' => PluginCreditBareme::getTypeName(Session::getPluralNumber()),
+    ];
 }
 
 function plugin_credit_get_datas(NotificationTargetTicket $target)

--- a/inc/bareme.class.php
+++ b/inc/bareme.class.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Credit plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Credit.
+ *
+ * Credit is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Credit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Credit. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @author    François Legastelois
+ * @copyright Copyright (C) 2017-2023 by Credit plugin team.
+ * @license   GPLv3 https://www.gnu.org/licenses/gpl-3.0.html
+ * @link      https://github.com/pluginsGLPI/credit
+ * -------------------------------------------------------------------------
+ */
+
+class PluginCreditBareme extends CommonDropdown
+{
+    public static $rightname = 'config';
+
+    public static function getTypeName($nb = 0)
+    {
+        return _sn('Rate scale', 'Rate scales', $nb, 'credit');
+    }
+
+    public static function getIcon()
+    {
+        return 'ti ti-calculator';
+    }
+
+    public function getAdditionalFields()
+    {
+        return [
+            [
+                'name'  => 'points_par_tranche',
+                'label' => __('Points per 15-minute slot', 'credit'),
+                'type'  => 'integer',
+                'min'   => 1,
+                'max'   => 9999,
+            ],
+        ];
+    }
+
+    public function rawSearchOptions()
+    {
+        $tab = parent::rawSearchOptions();
+        $tab[] = [
+            'id'       => 10,
+            'table'    => self::getTable(),
+            'field'    => 'points_par_tranche',
+            'name'     => __('Points per 15-minute slot', 'credit'),
+            'datatype' => 'number',
+        ];
+        return $tab;
+    }
+
+    /**
+     * Get all baremes as id => [name, points_par_tranche] map.
+     */
+    public static function getAllBaremes(): array
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $baremes = [];
+        foreach ($DB->request(['FROM' => self::getTable(), 'ORDER' => 'name']) as $row) {
+            $baremes[$row['id']] = [
+                'name'              => $row['name'],
+                'points_par_tranche' => (int) $row['points_par_tranche'],
+            ];
+        }
+        return $baremes;
+    }
+
+    /**
+     * Get points_par_tranche for a given bareme id.
+     */
+    public static function getPointsParTranche(int $bareme_id): int
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $row = $DB->request([
+            'SELECT' => ['points_par_tranche'],
+            'FROM'   => self::getTable(),
+            'WHERE'  => ['id' => $bareme_id],
+        ])->current();
+
+        return $row ? (int) $row['points_par_tranche'] : 0;
+    }
+
+    /**
+     * Calculate points from duration (seconds) and bareme id.
+     * Formula: ceil(duration_minutes / 15) * points_par_tranche
+     * Each started 15-minute slot counts as a full slot.
+     */
+    public static function calculatePoints(int $duration_seconds, int $bareme_id): int
+    {
+        if ($duration_seconds <= 0 || $bareme_id <= 0) {
+            return 0;
+        }
+        $duration_minutes  = $duration_seconds / 60;
+        $tranches          = (int) ceil($duration_minutes / 15);
+        $points_par_tranche = self::getPointsParTranche($bareme_id);
+        return $tranches * $points_par_tranche;
+    }
+
+    /**
+     * Install the bareme table and seed default values.
+     */
+    public static function install(Migration $migration): bool
+    {
+        /** @var DBmysql $DB */
+        global $DB;
+
+        $default_charset   = DBConnection::getDefaultCharset();
+        $default_collation = DBConnection::getDefaultCollation();
+        $default_key_sign  = DBConnection::getDefaultPrimaryKeySignOption();
+        $table             = self::getTable();
+
+        if (!$DB->tableExists($table)) {
+            $query = <<<SQL
+                CREATE TABLE IF NOT EXISTS `$table` (
+                    `id` int {$default_key_sign} NOT NULL auto_increment,
+                    `entities_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+                    `is_recursive` tinyint NOT NULL DEFAULT '0',
+                    `name` varchar(255) DEFAULT NULL,
+                    `points_par_tranche` int NOT NULL DEFAULT '0',
+                    `comment` text,
+                    `date_mod` timestamp NULL DEFAULT NULL,
+                    `date_creation` timestamp NULL DEFAULT NULL,
+                    PRIMARY KEY (`id`),
+                    KEY `name` (`name`),
+                    KEY `entities_id` (`entities_id`)
+                ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;
+SQL;
+            $DB->doQuery($query);
+
+            // Seed the four default rate scales
+            $now      = date('Y-m-d H:i:s');
+            $defaults = [
+                ['name' => 'ING (Ingénieur)',    'points_par_tranche' => 33],
+                ['name' => 'TECH (Technicien)',   'points_par_tranche' => 28],
+                ['name' => 'SOIR-WEEKEND',        'points_par_tranche' => 44],
+                ['name' => 'FERIE',               'points_par_tranche' => 58],
+            ];
+            foreach ($defaults as $bareme) {
+                $DB->insert($table, array_merge($bareme, [
+                    'entities_id'   => 0,
+                    'is_recursive'  => 1,
+                    'date_creation' => $now,
+                    'date_mod'      => $now,
+                ]));
+            }
+        } else {
+            // Ensure column exists on existing installs
+            if (!$DB->fieldExists($table, 'points_par_tranche')) {
+                $migration->addField($table, 'points_par_tranche', 'int NOT NULL DEFAULT 0');
+                $migration->executeMigration();
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Uninstall the bareme table.
+     */
+    public static function uninstall(Migration $migration): bool
+    {
+        $migration->dropTable(self::getTable());
+        return true;
+    }
+}

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -371,6 +371,8 @@ class PluginCreditTicket extends CommonDBTM
             'condition'             => PluginCreditEntity::getActiveFilter(),
             'creditentityclass'     => PluginCreditEntity::class,
             'plugin_credit_geturl'  => plugin_credit_geturl(),
+            'is_task'               => $item instanceof TicketTask,
+            'baremes'               => PluginCreditBareme::getAllBaremes(),
         ]);
     }
 
@@ -512,10 +514,28 @@ class PluginCreditTicket extends CommonDBTM
             }
         }
 
+        // Auto-calculate quantity from task duration + bareme when both are provided.
+        $quantity = (int) ($item->input['plugin_credit_quantity'] ?? 1);
+        if (
+            $item instanceof TicketTask
+            && !empty($item->input['plugin_credit_bareme_id'])
+            && (int) $item->input['plugin_credit_bareme_id'] > 0
+            && isset($item->fields['actiontime'])
+            && (int) $item->fields['actiontime'] > 0
+        ) {
+            $calculated = PluginCreditBareme::calculatePoints(
+                (int) $item->fields['actiontime'],
+                (int) $item->input['plugin_credit_bareme_id'],
+            );
+            if ($calculated > 0) {
+                $quantity = $calculated;
+            }
+        }
+
         $input = [
             'tickets_id'                => $ticket->getID(),
             'plugin_credit_entities_id' => $item->input['plugin_credit_entities_id'],
-            'consumed'                  => $item->input['plugin_credit_quantity'],
+            'consumed'                  => $quantity,
             'users_id'                  => Session::getLoginUserID(),
         ];
         if ($credit_ticket->add($input)) {

--- a/locales/fr_FR.po
+++ b/locales/fr_FR.po
@@ -225,3 +225,27 @@ msgstr "Alerte de crédit faible"
 #: inc/entity.class.php:339
 msgid "Notice (in days)"
 msgstr "Préavis (en jours)"
+
+#: inc/bareme.class.php templates/tickets/consume.html.twig
+msgid "Rate scale"
+msgstr "Barème tarifaire"
+
+#: inc/bareme.class.php templates/tickets/consume.html.twig
+msgid "Rate scales"
+msgstr "Barèmes tarifaires"
+
+#: inc/bareme.class.php
+msgid "Points per 15-minute slot"
+msgstr "Points par tranche de 15 minutes"
+
+#: templates/tickets/consume.html.twig
+msgid "-- Manual entry --"
+msgstr "-- Saisie manuelle --"
+
+#: templates/tickets/consume.html.twig
+msgid "Auto-calculated points"
+msgstr "Points calculés automatiquement"
+
+#: templates/tickets/consume.html.twig
+msgid "Duration not set yet"
+msgstr "Durée non encore définie"

--- a/setup.php
+++ b/setup.php
@@ -62,6 +62,8 @@ function plugin_init_credit()
             ],
         );
 
+        Plugin::registerClass('PluginCreditBareme');
+
         if (Session::haveRightsOr('ticket', [Ticket::STEAL, Ticket::OWN])) {
             Plugin::registerClass('PluginCreditTicket', ['addtabon' => 'Ticket']);
 

--- a/templates/tickets/consume.html.twig
+++ b/templates/tickets/consume.html.twig
@@ -65,6 +65,41 @@
                 }
             ) }}
 
+            {% if is_task and baremes|length > 0 %}
+                {# Bareme dropdown — only shown for task forms #}
+                <div class="col-6 col-sm-6">
+                    <div class="row mb-2">
+                        <label class="col-xxl-5 col-form-label">
+                            {{ __('Rate scale', 'credit') }}
+                        </label>
+                        <div class="col-xxl-7">
+                            <select id="plugin_credit_bareme_id_{{ rand }}"
+                                    name="plugin_credit_bareme_id"
+                                    class="form-select"
+                                    onchange="onBaremeChange{{ rand }}()">
+                                <option value="0">{{ __('-- Manual entry --', 'credit') }}</option>
+                                {% for id, bareme in baremes %}
+                                    <option value="{{ id }}" data-points="{{ bareme.points_par_tranche }}">
+                                        {{ bareme.name }} ({{ bareme.points_par_tranche }} pts / 15 min)
+                                    </option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                    </div>
+                </div>
+
+                {# Auto-calculation preview badge #}
+                <div class="col-12 mb-2" id="credit_auto_calc_block_{{ rand }}" style="display:none;">
+                    <div class="alert alert-info py-2 px-3 mb-0 d-flex align-items-center gap-2">
+                        <i class="ti ti-calculator"></i>
+                        <span>
+                            {{ __('Auto-calculated points', 'credit') }} :
+                            <strong id="credit_auto_calc_detail_{{ rand }}">—</strong>
+                        </span>
+                    </div>
+                </div>
+            {% endif %}
+
             {{ fields.numberField(
                 'plugin_credit_quantity',
                 1,
@@ -126,8 +161,105 @@
                     quantity.value = 1;
                     quantity_label.querySelector('span.form-help').setAttribute('data-bs-title', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
                     quantity_label.querySelector('span.form-help').setAttribute('data-bs-content', __('Maximum consumable quantity', 'credit') + ' : <b>' + data);
+                    // Recalculate if bareme is selected
+                    onBaremeChange{{ rand }}();
                 });
             }
         }
+
+        {% if is_task %}
+        /**
+         * Read the current task duration in seconds from the GLPI task form.
+         * GLPI 11 uses a hidden input named "actiontime" (seconds) fed by
+         * a duration picker (hours + minutes selects or a time input).
+         * We also try to reconstruct from named sub-fields if present.
+         */
+        function getTaskDurationSeconds{{ rand }}() {
+            // Primary source: hidden actiontime (seconds) used by GLPI 11 task forms
+            var actiontimeInput = document.querySelector('input[name="actiontime"]')
+                               || document.querySelector('[name="actiontime"]');
+            if (actiontimeInput && parseInt(actiontimeInput.value) > 0) {
+                return parseInt(actiontimeInput.value);
+            }
+
+            // Fallback: reconstruct from "actiontime_hour" + "actiontime_minute" selects
+            // (some GLPI versions render duration as separate hour/minute fields)
+            var hourSel   = document.querySelector('select[name="actiontime_hour"]');
+            var minuteSel = document.querySelector('select[name="actiontime_minute"]');
+            if (hourSel && minuteSel) {
+                var h = parseInt(hourSel.value) || 0;
+                var m = parseInt(minuteSel.value) || 0;
+                return (h * 3600) + (m * 60);
+            }
+
+            return 0;
+        }
+
+        function onBaremeChange{{ rand }}() {
+            var baremeSelect = document.getElementById('plugin_credit_bareme_id_{{ rand }}');
+            var autoBlock    = document.getElementById('credit_auto_calc_block_{{ rand }}');
+            var autoDetail   = document.getElementById('credit_auto_calc_detail_{{ rand }}');
+            var consumeblock = document.querySelector('[name="credit_consume_{{ rand }}"]');
+            var quantityInput = consumeblock
+                ? consumeblock.querySelector('[id*="plugin_credit_quantity_{{ rand }}"]')
+                : null;
+
+            if (!baremeSelect) return;
+
+            var baremeId = parseInt(baremeSelect.value) || 0;
+
+            if (baremeId === 0) {
+                // Manual mode: hide auto-calc block, re-enable quantity field
+                if (autoBlock)    autoBlock.style.display = 'none';
+                if (quantityInput) {
+                    quantityInput.removeAttribute('readonly');
+                    quantityInput.classList.remove('bg-secondary-subtle');
+                }
+                return;
+            }
+
+            // Auto-calc mode: make quantity field read-only (server will override anyway)
+            if (quantityInput) {
+                quantityInput.setAttribute('readonly', 'readonly');
+                quantityInput.classList.add('bg-secondary-subtle');
+            }
+            if (autoBlock) autoBlock.style.display = 'block';
+
+            var durationSeconds = getTaskDurationSeconds{{ rand }}();
+            if (durationSeconds <= 0) {
+                if (autoDetail) autoDetail.textContent = '{{ __('Duration not set yet', 'credit') }}';
+                return;
+            }
+
+            var durationMinutes = durationSeconds / 60;
+            var tranches        = Math.ceil(durationMinutes / 15);
+            var selectedOption  = baremeSelect.options[baremeSelect.selectedIndex];
+            var ptsPerTranche   = parseInt(selectedOption.getAttribute('data-points')) || 0;
+            var points          = tranches * ptsPerTranche;
+
+            if (autoDetail) {
+                autoDetail.textContent = points + ' pts'
+                    + ' (' + tranches + ' × ' + ptsPerTranche + ' pts)';
+            }
+            if (quantityInput && !isNaN(points)) {
+                quantityInput.value = points;
+            }
+        }
+
+        // Watch duration field changes so the preview updates automatically.
+        (function watchDuration{{ rand }}() {
+            var targets = [
+                document.querySelector('input[name="actiontime"]'),
+                document.querySelector('[name="actiontime"]'),
+                document.querySelector('select[name="actiontime_hour"]'),
+                document.querySelector('select[name="actiontime_minute"]'),
+            ].filter(Boolean);
+
+            targets.forEach(function(el) {
+                el.addEventListener('change', onBaremeChange{{ rand }});
+                el.addEventListener('input',  onBaremeChange{{ rand }});
+            });
+        })();
+        {% endif %}
     </script>
 </div>


### PR DESCRIPTION
…cale

Adds a configurable rate scale (barème) system so that consumed credit points are automatically computed when a technician adds a task to a ticket.

Rules implemented:
- 1 slot = 15 minutes, any started slot counts as a full one (ceil)
- Points = ceil(duration_min / 15) × points_per_slot
- Default scales seeded: ING (33 pts), TECH (28 pts), SOIR-WEEKEND (44 pts), FERIE (58 pts)

Changes:
- inc/bareme.class.php: new PluginCreditBareme CommonDropdown class with install/uninstall, default seed, and calculatePoints() helper
- ajax/calculatePoints.php: AJAX endpoint used by the JS preview
- inc/ticket.class.php: consumeVoucher() overrides quantity when a bareme is selected on a TicketTask; passes is_task + baremes to the Twig template
- templates/tickets/consume.html.twig: bareme dropdown + live auto-calc preview (read-only quantity field when bareme is active); watchers on GLPI's actiontime duration field for real-time update
- hook.php: register PluginCreditBareme in plugin_credit_getDropdown()
- setup.php: register PluginCreditBareme class
- locales/fr_FR.po: French translations for new UI strings

https://claude.ai/code/session_01Dv3uv27Ry3xH1QfV3SWEUr

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):
