### PR TITLE
fix: prevent duplicate low credit alerts in cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fixed the minimum consumable quantity at 1
+- Fix duplicate “low credits” alert generation in the cron job.
 
 ## [1.15.3] - 2026-04-29
 

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -481,8 +481,11 @@ class PluginCreditEntity extends CommonDBTM
                 'itemtype' => self::getType(),
                 'items_id' => $credit_data['id'],
             ];
-            $alert->add($input);
-            unset($alert->fields['id']);
+
+            if (countElementsInTable(Alert::getTable(), $input) === 0) {
+                $alert->add($input);
+                unset($alert->fields['id']);
+            }
         }
 
         return 1;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43646
- Fix duplicate “low credits” alert generation in the cron job.
Add an existence check before inserting into glpi_alerts.
Prevent errors caused by repeated insertions.

## Screenshots (if appropriate):
