### PR TITLE
Fix: correct entity and ticket validation in credit forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Improve entity and ticket validation across credit voucher forms
+
 ## [1.15.5] - 2026-06-24
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/ajax/dropdownQuantity.php
+++ b/ajax/dropdownQuantity.php
@@ -29,6 +29,8 @@
  * -------------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\AccessDeniedHttpException;
+
 header("Content-Type: text/html; charset=UTF-8");
 Html::header_nocache();
 
@@ -36,6 +38,13 @@ Html::header_nocache();
 global $DB;
 
 if (isset($_POST["entity"])) {
+    $credit_entity = new PluginCreditEntity();
+    if (
+        !$credit_entity->getFromDB($_POST["entity"])
+        || !Session::haveAccessToEntity($credit_entity->getField('entities_id'), $credit_entity->getField('is_recursive'))
+    ) {
+        throw new AccessDeniedHttpException();
+    }
     $max = PluginCreditEntity::getMaximumConsumptionForCredit($_POST["entity"]);
     echo $max;
 }

--- a/front/entityconfig.form.php
+++ b/front/entityconfig.form.php
@@ -38,7 +38,7 @@ if (isset($_POST["add"])) {
     $entity_config->add($_POST);
     Html::back();
 } elseif (isset($_POST["update"])) {
-    $entity_config->check(-1, UPDATE, $_POST);
+    $entity_config->check($_POST['id'] ?? -1, UPDATE, $_POST);
     $entity_config->update($_POST);
     Html::back();
 }

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -59,7 +59,7 @@ if ($_REQUEST['plugin_credit_entities_id'] == 0) {
     Html::back();
 }
 
-if (Session::haveAccessToEntity($_REQUEST['plugin_credit_entities_id'])) {
+if (!Session::haveAccessToEntity($_REQUEST['plugin_credit_entities_id'])) {
     throw new AccessDeniedHttpException();
 }
 

--- a/front/ticket.php
+++ b/front/ticket.php
@@ -29,6 +29,8 @@
  * -------------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\AccessDeniedHttpException;
+
 Html::popHeader(__('Setup'), $_SERVER['PHP_SELF'], true);
 
 if (!isset($_GET["plugcreditentity"])) {
@@ -39,6 +41,14 @@ if (!isset($_GET["plugcreditentity"])) {
 
 Session::checkLoginUser();
 Session::checkRightsOr('ticket', [Ticket::STEAL, Ticket::OWN]);
+
+$credit_entity = new PluginCreditEntity();
+if (
+    !$credit_entity->getFromDB($_GET['plugcreditentity'])
+    || !Session::haveAccessToEntity($credit_entity->getField('entities_id'), $credit_entity->getField('is_recursive'))
+) {
+    throw new AccessDeniedHttpException();
+}
 
 PluginCreditTicket::displayConsumed($_GET['plugcreditentity']);
 

--- a/front/ticketconfig.form.php
+++ b/front/ticketconfig.form.php
@@ -41,6 +41,10 @@ if (!Session::haveRight($ticket_config::$rightname, PluginCreditTicketConfig::TI
 
 if (isset($_POST["update"])) {
     $tickets_id = (int) $_POST['tickets_id'];
+    $ticket = new Ticket();
+    if (!$ticket->getFromDB($tickets_id) || !Session::haveAccessToEntity($ticket->getEntityID())) {
+        throw new BadRequestHttpException();
+    }
     if ($ticket_config->getFromDBByCrit(['tickets_id' => $tickets_id])) {
         $_POST['id'] = $ticket_config->getID();
         $ticket_config->update($_POST);

--- a/inc/entity.class.php
+++ b/inc/entity.class.php
@@ -73,16 +73,6 @@ class PluginCreditEntity extends CommonDBTM
         return $menu;
     }
 
-    public static function canCreate(): bool
-    {
-        return true;
-    }
-
-    public function canCreateItem(): bool
-    {
-        return true;
-    }
-
     public function getTabNameForItem(CommonGLPI $item, $withtemplate = 0)
     {
         if ($item instanceof Entity) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- This fixes several forms and endpoints of the Credit plugin so that voucher creation, voucher configuration and ticket consumption records are always validated against the correct entity and the correct ticket.
- Previously some of these checks were missing, inverted, or applied to the wrong record, which could let a request affect a voucher or a ticket outside the caller's expected scope.
- The consumption history view and the quantity preview endpoint now also verify entity access before returning data.

## Screenshots (if appropriate):
