### PR TITLE
1.15.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [1.15.7] - 2026-08-31
 
 ### Fixed
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -25,6 +25,11 @@
    </authors>
    <versions>
       <version>
+         <num>1.15.7</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/credit/releases/download/1.15.7/glpi-credit-1.15.7.tar.bz2</download_url>
+      </version>
+      <version>
          <num>1.15.6</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/credit/releases/download/1.15.6/glpi-credit-1.15.6.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@
 
 use function Safe\define;
 
-define('PLUGIN_CREDIT_VERSION', '1.15.6');
+define('PLUGIN_CREDIT_VERSION', '1.15.7');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_CREDIT_MIN_GLPI", "11.0.0");


### PR DESCRIPTION
## [1.15.7] - 2026-08-31

### Fixed

-  Validate entity access in consumeVoucher before recording